### PR TITLE
modified the double-signing to single signing, test passed using secp256k1 pubkey

### DIFF
--- a/helpers/antehelper.go
+++ b/helpers/antehelper.go
@@ -5,6 +5,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	registertypes "github.com/stratosnet/stratos-chain/x/register/types"
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/ed25519"
 	"github.com/tendermint/tendermint/crypto/multisig"
@@ -20,7 +21,7 @@ func StSigVerificationGasConsumer(
 	switch pubkey := pubkey.(type) {
 	case ed25519.PubKeyEd25519:
 		meter.ConsumeGas(params.SigVerifyCostED25519, "ante verify: ed25519")
-		return nil
+		return registertypes.ErrED25519InvalidPubKey
 
 	case secp256k1.PubKeySecp256k1:
 		meter.ConsumeGas(params.SigVerifyCostSecp256k1, "ante verify: secp256k1")

--- a/x/register/allow_ed25519_gas_test.go
+++ b/x/register/allow_ed25519_gas_test.go
@@ -25,14 +25,9 @@ func TestRegister(t *testing.T) {
 	header = abci.Header{Height: mApp.LastBlockHeight() + 1}
 	ctx = mApp.BaseApp.NewContext(true, header)
 
-	t.Log("resNodePrivKey3: ", resNodePrivKey3)
-	t.Log("resNodePubKey3: ", resNodePubKey3)
-	resNodeAcc3 := mApp.AccountKeeper.GetAccount(ctx, resNodeAddr3)
-	t.Log("resNodeAcc3: ", resNodeAcc3)
-
 	registerResNodeMsg := types.NewMsgCreateResourceNode(
 		"sds://resourceNode3",
-		resNodePubKey3,
+		resOwnerPrivKey3.PubKey(),
 		sdk.NewCoin(k.BondDenom(ctx), resNodeInitStake),
 		resOwnerAddr3,
 		NewDescription("sds://resourceNode3", "", "", "", ""),
@@ -40,17 +35,17 @@ func TestRegister(t *testing.T) {
 	)
 	t.Log("registerResNodeMsg: ", registerResNodeMsg)
 
-	resNodeOwnerAcc3 := mApp.AccountKeeper.GetAccount(ctx, resOwnerAddr3)
-	accNumOwner := resNodeOwnerAcc3.GetAccountNumber()
+	resOwnerAcc3 := mApp.AccountKeeper.GetAccount(ctx, resOwnerAddr3)
+	accNumOwner := resOwnerAcc3.GetAccountNumber()
 	t.Log("accNumOwner: ", accNumOwner)
-	accSeqOwner := resNodeOwnerAcc3.GetSequence()
+	accSeqOwner := resOwnerAcc3.GetSequence()
 	t.Log("accSeqOwner: ", accSeqOwner)
 	t.Log("resOwnerPrivKey3: ", resOwnerPrivKey3)
 	t.Log("resOwnerPubKey3: ", resOwnerPrivKey3.PubKey())
 
-	accNumNode := resNodeAcc3.GetAccountNumber()
+	accNumNode := resOwnerAcc3.GetAccountNumber()
 	t.Log("accNumNode: ", accNumNode)
-	accSeqNode := resNodeAcc3.GetSequence()
+	accSeqNode := resOwnerAcc3.GetSequence()
 	t.Log("accSeqNode: ", accSeqNode)
 
 	gasInfo, result, e := mock.SignCheckDeliver(
@@ -64,7 +59,6 @@ func TestRegister(t *testing.T) {
 		true,
 		true,
 		resOwnerPrivKey3,
-		resNodePrivKey3,
 	)
 
 	if e != nil {

--- a/x/register/allow_ed25519_gas_test.go
+++ b/x/register/allow_ed25519_gas_test.go
@@ -27,7 +27,7 @@ func TestRegister(t *testing.T) {
 
 	registerResNodeMsg := types.NewMsgCreateResourceNode(
 		"sds://resourceNode3",
-		resOwnerPrivKey3.PubKey(),
+		resNodePubKey3,
 		sdk.NewCoin(k.BondDenom(ctx), resNodeInitStake),
 		resOwnerAddr3,
 		NewDescription("sds://resourceNode3", "", "", "", ""),

--- a/x/register/register_test.go
+++ b/x/register/register_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	authexported "github.com/cosmos/cosmos-sdk/x/auth/exported"
 	"github.com/cosmos/cosmos-sdk/x/mock"
+	"github.com/tendermint/tendermint/crypto/ed25519"
 	"github.com/tendermint/tendermint/crypto/secp256k1"
 )
 
@@ -40,8 +41,8 @@ var (
 
 	resNodePrivKey1 = secp256k1.GenPrivKey()
 	resNodePrivKey2 = secp256k1.GenPrivKey()
-	//resNodePrivKey3 = ed25519.GenPrivKey()
-	resNodePrivKey3 = secp256k1.GenPrivKey()
+	resNodePrivKey3 = ed25519.GenPrivKey()
+	//resNodePrivKey3 = secp256k1.GenPrivKey()
 	idxNodePrivKey1 = secp256k1.GenPrivKey()
 	idxNodePrivKey2 = secp256k1.GenPrivKey()
 	idxNodePrivKey3 = secp256k1.GenPrivKey()

--- a/x/register/register_test.go
+++ b/x/register/register_test.go
@@ -5,7 +5,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	authexported "github.com/cosmos/cosmos-sdk/x/auth/exported"
 	"github.com/cosmos/cosmos-sdk/x/mock"
-	"github.com/tendermint/tendermint/crypto/ed25519"
 	"github.com/tendermint/tendermint/crypto/secp256k1"
 )
 
@@ -23,8 +22,8 @@ var (
 
 	resOwnerPrivKey1 = secp256k1.GenPrivKey()
 	resOwnerPrivKey2 = secp256k1.GenPrivKey()
-	resOwnerPrivKey3 = ed25519.GenPrivKey()
-	//resOwnerPrivKey3 = secp256k1.GenPrivKey()
+	//resOwnerPrivKey3 = ed25519.GenPrivKey()
+	resOwnerPrivKey3 = secp256k1.GenPrivKey()
 	idxOwnerPrivKey1 = secp256k1.GenPrivKey()
 	idxOwnerPrivKey2 = secp256k1.GenPrivKey()
 	idxOwnerPrivKey3 = secp256k1.GenPrivKey()

--- a/x/register/types/errors.go
+++ b/x/register/types/errors.go
@@ -34,4 +34,5 @@ var (
 	ErrInsufficientBalanceOfBondedPool    = sdkerrors.Register(ModuleName, 27, "insufficient balance of bonded pool")
 	ErrInsufficientBalanceOfNotBondedPool = sdkerrors.Register(ModuleName, 28, "insufficient balance of not bonded pool")
 	ErrSubAllTokens                       = sdkerrors.Register(ModuleName, 29, "error sub all tokens")
+	ErrED25519InvalidPubKey               = sdkerrors.Register(ModuleName, 30, "ED25519 public keys are unsupported")
 )

--- a/x/register/types/msg.go
+++ b/x/register/types/msg.go
@@ -1,8 +1,6 @@
 package types
 
 import (
-	"bytes"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/tendermint/tendermint/crypto"
 )
@@ -23,7 +21,6 @@ type MsgCreateResourceNode struct {
 	OwnerAddress sdk.AccAddress `json:"owner_address" yaml:"owner_address"`
 	Description  Description    `json:"description" yaml:"description"`
 	NodeType     string         `json:"node_type" yaml:"node_type"`
-	NodeSign     string         `json:"node_sign" yaml:"node_sign"`
 }
 
 // NewMsgCreateResourceNode NewMsg<Action> creates a new Msg<Action> instance
@@ -75,13 +72,8 @@ func (msg MsgCreateResourceNode) GetSignBytes() []byte {
 }
 
 func (msg MsgCreateResourceNode) GetSigners() []sdk.AccAddress {
-	// OwnerAddress is first signer so Owner pays fees
-	// and since the second signer is used for validating the tx, it does not pay for proposing the tx. The tx should be signed in the same order.
+	// Owner pays the tx fees
 	addrs := []sdk.AccAddress{msg.OwnerAddress}
-
-	if !bytes.Equal(msg.OwnerAddress.Bytes(), msg.PubKey.Address().Bytes()) {
-		addrs = append(addrs, msg.PubKey.Address().Bytes())
-	}
 	return addrs
 }
 
@@ -140,12 +132,8 @@ func (msg MsgCreateIndexingNode) GetSignBytes() []byte {
 }
 
 func (msg MsgCreateIndexingNode) GetSigners() []sdk.AccAddress {
-	// OwnerAddress is first signer so Owner pays fees
+	// Owner pays the tx fees
 	addrs := []sdk.AccAddress{msg.OwnerAddress}
-
-	if !bytes.Equal(msg.OwnerAddress.Bytes(), msg.PubKey.Address().Bytes()) {
-		addrs = append(addrs, msg.PubKey.Address().Bytes())
-	}
 	return addrs
 }
 


### PR DESCRIPTION
1. in ./x/register/types/errors.go, added  `ErrED25519InvalidPubKey`
2. in ./helpers/antehelper.go, change to` return registertypes.ErrED25519InvalidPubKey`
3. in ./x/register/msg.go, removed `Nodesign ` in `MsgCreateResourceNode `. Removed the two signers (keep only owner) in `GetSigners` for both resource node and indexing node. 
4. Unit test passed using secp256k1 pubkey and got an error "ED25519 public keys are unsupported" if using ED25519 pubkey.