### PR TITLE
QB-446 CreateResourceNode Returns Pubkey

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ build-linux: go.sum
 build-mac: go.sum
 	LEDGER_ENABLED=false GOOS=darwin GOARCH=amd64 $(MAKE) build
 
+build-windows: go.sum
+	LEDGER_ENABLED=false GOOS=windows GOARCH=amd64 $(MAKE) build
+
 clean:
 	rm -rf $(BUILDDIR)/
 

--- a/x/register/handler.go
+++ b/x/register/handler.go
@@ -1,6 +1,7 @@
 package register
 
 import (
+	"encoding/hex"
 	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -57,6 +58,7 @@ func handleMsgCreateResourceNode(ctx sdk.Context, msg types.MsgCreateResourceNod
 			types.EventTypeCreateResourceNode,
 			sdk.NewAttribute(sdk.AttributeKeySender, msg.OwnerAddress.String()),
 			sdk.NewAttribute(types.AttributeKeyNodeAddress, sdk.AccAddress(msg.PubKey.Address()).String()),
+			sdk.NewAttribute(types.AttributeKeyNodePubkey, hex.EncodeToString(msg.PubKey.Bytes())),
 		),
 		sdk.NewEvent(
 			sdk.EventTypeMessage,

--- a/x/register/types/events.go
+++ b/x/register/types/events.go
@@ -12,6 +12,7 @@ const (
 	AttributeKeyResourceNode = "resource_node"
 	AttributeKeyIndexingNode = "indexing_node"
 	AttributeKeyNodeAddress  = "node_address"
+	AttributeKeyNodePubkey   = "node_pubkey"
 
 	AttributeValueCategory = ModuleName
 )


### PR DESCRIPTION
https://qsn.atlassian.net/browse/QB-446
Associated PR: [SDS#21](https://github.com/stratosnet/sds/pull/21)
The CreateResourceNode message will now publish the pubkey in the event instead of only the address.