### PR TITLE
Qb 548 add ozone related apis

### DIFF
--- a/x/sds/client/common/common.go
+++ b/x/sds/client/common/common.go
@@ -13,7 +13,7 @@ import (
 func QueryUploadedFile(cliCtx context.CLIContext, queryRoute, fileHashHex string) ([]byte, int64, error) {
 	fileHashByteArr, err := hex.DecodeString(fileHashHex)
 	if err != nil {
-		return nil, 0, fmt.Errorf("Invalid file hash, please specify a hash in hex format %w", err)
+		return nil, 0, fmt.Errorf("invalid file hash, please specify a hash in hex format %w", err)
 	}
 	route := fmt.Sprintf("custom/%s/%s", queryRoute, sds.QueryUploadedFile)
 	return cliCtx.QueryWithData(route, fileHashByteArr)
@@ -23,8 +23,18 @@ func QueryUploadedFile(cliCtx context.CLIContext, queryRoute, fileHashHex string
 func QueryPrepayBalance(cliCtx context.CLIContext, queryRoute, sender string) ([]byte, int64, error) {
 	accAddr, err := sdk.AccAddressFromBech32(sender)
 	if err != nil {
-		return nil, 0, fmt.Errorf("Invalid sender, please specify a sender in Bech32 format %w", err)
+		return nil, 0, fmt.Errorf("invalid sender, please specify a sender in Bech32 format %w", err)
 	}
 	route := fmt.Sprintf("custom/%s/%s", queryRoute, sds.QueryPrepay)
 	return cliCtx.QueryWithData(route, accAddr)
+}
+
+// QuerySimulatePrepay queries the ongoing price for prepay
+func QuerySimulatePrepay(cliCtx context.CLIContext, queryRoute string, amtToPrepay sdk.Int) ([]byte, int64, error) {
+	amtByteArry, err := amtToPrepay.MarshalJSON()
+	if err != nil {
+		return nil, 0, fmt.Errorf("invalid amount, please specify a valid amount to simulate prepay %w", err)
+	}
+	route := fmt.Sprintf("custom/%s/%s", queryRoute, sds.QuerySimulatePrepay)
+	return cliCtx.QueryWithData(route, amtByteArry)
 }

--- a/x/sds/client/common/common.go
+++ b/x/sds/client/common/common.go
@@ -31,10 +31,22 @@ func QueryPrepayBalance(cliCtx context.CLIContext, queryRoute, sender string) ([
 
 // QuerySimulatePrepay queries the ongoing price for prepay
 func QuerySimulatePrepay(cliCtx context.CLIContext, queryRoute string, amtToPrepay sdk.Int) ([]byte, int64, error) {
-	amtByteArry, err := amtToPrepay.MarshalJSON()
+	amtByteArray, err := amtToPrepay.MarshalJSON()
 	if err != nil {
 		return nil, 0, fmt.Errorf("invalid amount, please specify a valid amount to simulate prepay %w", err)
 	}
 	route := fmt.Sprintf("custom/%s/%s", queryRoute, sds.QuerySimulatePrepay)
-	return cliCtx.QueryWithData(route, amtByteArry)
+	return cliCtx.QueryWithData(route, amtByteArray)
+}
+
+// QueryCurrUozPrice queries the current price for uoz
+func QueryCurrUozPrice(cliCtx context.CLIContext, queryRoute string) ([]byte, int64, error) {
+	route := fmt.Sprintf("custom/%s/%s", queryRoute, sds.QueryCurrUozPrice)
+	return cliCtx.QueryWithData(route, nil)
+}
+
+// QueryCurrUozPrice queries the current price for uoz
+func QueryUozSupply(cliCtx context.CLIContext, queryRoute string) ([]byte, int64, error) {
+	route := fmt.Sprintf("custom/%s/%s", queryRoute, sds.QueryUozSupply)
+	return cliCtx.QueryWithData(route, nil)
 }

--- a/x/sds/client/rest/query.go
+++ b/x/sds/client/rest/query.go
@@ -1,0 +1,58 @@
+package rest
+
+import (
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/stratosnet/stratos-chain/x/sds/client/common"
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	"github.com/cosmos/cosmos-sdk/client/context"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/rest"
+)
+
+func registerSdsQueryRoutes(cliCtx context.CLIContext, r *mux.Router, queryRoute string) {
+	r.HandleFunc(
+		"/sds/simulatePrepay/{amtToPrepay}",
+		SimulatePrelayHandlerFn(cliCtx, queryRoute),
+	).Methods("GET")
+}
+
+// HTTP request handler to query the total rewards balance from all delegations
+func SimulatePrelayHandlerFn(cliCtx context.CLIContext, queryRoute string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		cliCtx, ok := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
+		if !ok {
+			return
+		}
+		amtToPrepay, ok := checkAmtToPrepayVar(w, r)
+		if !ok {
+			return
+		}
+		resp, height, err := common.QuerySimulatePrepay(cliCtx, queryRoute, amtToPrepay)
+
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		var simulatePrepayOut sdk.Int
+		err = simulatePrepayOut.UnmarshalJSON(resp)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		cliCtx = cliCtx.WithHeight(height)
+		rest.PostProcessResponse(w, cliCtx, simulatePrepayOut)
+	}
+}
+
+func checkAmtToPrepayVar(w http.ResponseWriter, r *http.Request) (sdk.Int, bool) {
+	prepayAmtStr := mux.Vars(r)["amtToPrepay"]
+	amtToPrepay, ok := sdk.NewIntFromString(prepayAmtStr)
+	if ok != true {
+		rest.WriteErrorResponse(w, http.StatusBadRequest, sdkerrors.ErrInvalidRequest.Error())
+		return sdk.Int{}, false
+	}
+	return amtToPrepay, true
+}

--- a/x/sds/client/rest/rest.go
+++ b/x/sds/client/rest/rest.go
@@ -14,10 +14,10 @@ import (
 )
 
 // RegisterRoutes registers sds-related REST handlers to a router
-func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router) {
+func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, queryRoute string) {
 	r.HandleFunc("/sds/file/upload", FileUploadRequestHandlerFn(cliCtx)).Methods("POST")
 	r.HandleFunc("/sds/prepay", PrepayRequestHandlerFn(cliCtx)).Methods("POST")
-
+	registerSdsQueryRoutes(cliCtx, r, queryRoute)
 }
 
 // FileUploadReq defines the properties of a file upload request's body.

--- a/x/sds/keeper/keeper.go
+++ b/x/sds/keeper/keeper.go
@@ -106,6 +106,27 @@ func (fk Keeper) simulatePurchaseUoz(ctx sdk.Context, amount sdk.Int) sdk.Int {
 	return purchased
 }
 
+// calc current uoz price
+func (fk Keeper) currUozPrice(ctx sdk.Context) sdk.Int {
+	S := fk.RegisterKeeper.GetInitialGenesisStakeTotal(ctx)
+	Pt := fk.PotKeeper.GetTotalUnissuedPrepay(ctx)
+	Lt := fk.RegisterKeeper.GetRemainingOzoneLimit(ctx)
+	currUozPrice := Lt.ToDec().
+		Quo((S.
+			Add(Pt)).ToDec()).
+		TruncateInt()
+	return currUozPrice
+}
+
+// calc remaining/total supply for uoz
+func (fk Keeper) uozSupply(ctx sdk.Context) (remaining, total sdk.Int) {
+	remaining = fk.RegisterKeeper.GetRemainingOzoneLimit(ctx)
+	// TODO create a dedicated storeKey in pot module for total ozone supply and keep updating it along with related operations (like AddResourceNodeStake)
+	// fake return of total
+	total, _ = sdk.NewIntFromString("-1")
+	return remaining, total
+}
+
 // Prepay transfers coins from bank to sds (volumn) pool
 func (fk Keeper) Prepay(ctx sdk.Context, sender sdk.AccAddress, coins sdk.Coins) (sdk.Int, error) {
 	// src - hasCoins?

--- a/x/sds/keeper/keeper.go
+++ b/x/sds/keeper/keeper.go
@@ -93,6 +93,19 @@ func (fk Keeper) purchaseUoz(ctx sdk.Context, amount sdk.Int) sdk.Int {
 	return purchased
 }
 
+func (fk Keeper) simulatePurchaseUoz(ctx sdk.Context, amount sdk.Int) sdk.Int {
+	S := fk.RegisterKeeper.GetInitialGenesisStakeTotal(ctx)
+	Pt := fk.PotKeeper.GetTotalUnissuedPrepay(ctx)
+	Lt := fk.RegisterKeeper.GetRemainingOzoneLimit(ctx)
+	purchased := Lt.ToDec().
+		Mul(amount.ToDec()).
+		Quo((S.
+			Add(Pt).
+			Add(amount)).ToDec()).
+		TruncateInt()
+	return purchased
+}
+
 // Prepay transfers coins from bank to sds (volumn) pool
 func (fk Keeper) Prepay(ctx sdk.Context, sender sdk.AccAddress, coins sdk.Coins) (sdk.Int, error) {
 	// src - hasCoins?

--- a/x/sds/module.go
+++ b/x/sds/module.go
@@ -57,7 +57,7 @@ func (AppModuleBasic) ValidateGenesis(bz json.RawMessage) error {
 
 // RegisterRESTRoutes registers the REST routes for the sds module.
 func (AppModuleBasic) RegisterRESTRoutes(ctx context.CLIContext, rtr *mux.Router) {
-	rest.RegisterRoutes(ctx, rtr)
+	rest.RegisterRoutes(ctx, rtr, StoreKey)
 }
 
 // GetTxCmd returns the root tx command for the sds module.

--- a/x/sds/types/querier.go
+++ b/x/sds/types/querier.go
@@ -8,6 +8,8 @@ const (
 	QueryUploadedFile   = "uploaded_file"
 	QueryPrepay         = "prepay"
 	QuerySimulatePrepay = "simulate_prepay"
+	QueryCurrUozPrice   = "curr_uoz_price"
+	QueryUozSupply      = "uoz_supply"
 )
 
 // params for query 'custom/distr/validator_outstanding_rewards'

--- a/x/sds/types/querier.go
+++ b/x/sds/types/querier.go
@@ -4,9 +4,10 @@ import "github.com/cosmos/cosmos-sdk/types"
 
 // querier keys
 const (
-	QueryParams       = "params"
-	QueryUploadedFile = "uploaded_file"
-	QueryPrepay       = "prepay"
+	QueryParams         = "params"
+	QueryUploadedFile   = "uploaded_file"
+	QueryPrepay         = "prepay"
+	QuerySimulatePrepay = "simulate_prepay"
 )
 
 // params for query 'custom/distr/validator_outstanding_rewards'


### PR DESCRIPTION
- Add rest api for sds/simulatePrepay/{amt}
- Add rest api for sds/uozPrice
- Add rest api for sds/uozSupply
- Modified loadtest.go to get adapted to increased gas consumption

Notes:
- Total uoz supply now returns a fake total, leaving TODO for later implementation since a series of changes ahead to be done
- Apis are created in sds module, since sds contains all needed dependencies (pot and register module)