### PR TITLE
QB-533 Indexing Node Vote Single Signer

### DIFF
--- a/x/register/types/msg.go
+++ b/x/register/types/msg.go
@@ -377,7 +377,6 @@ func (m MsgIndexingNodeRegistrationVote) GetSignBytes() []byte {
 
 func (m MsgIndexingNodeRegistrationVote) GetSigners() []sdk.AccAddress {
 	var addrs []sdk.AccAddress
-	addrs = append(addrs, m.VoterNetworkAddress)
 	addrs = append(addrs, m.VoterOwnerAddress)
 	return addrs
 }


### PR DESCRIPTION
https://qsn.atlassian.net/browse/QB-533
Removing the second signer for the IndexingNodeRegistrationVote message because the `VoterNetworkAddress` is an ed25519 key, which isn't supported by cosmos-sdk.