### PR TITLE
updated vue dependency according to denpendabot alert

### DIFF
--- a/vue/package-lock.json
+++ b/vue/package-lock.json
@@ -19,7 +19,7 @@
       "integrity": "sha512-TPSvJfv73ng0pfnEOh17bYMPQbI95+nGWc71Ss4vZdRBHTDqmM9Z8ZV4rYz8Ks7sfzc95n30k6ODIq5UGnXcYQ==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.12.0",
+        "browserslist": "^4.16.5",
         "invariant": "^2.2.4",
         "semver": "^5.5.0"
       }
@@ -42,7 +42,7 @@
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
         "json5": "^2.1.2",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
@@ -102,7 +102,7 @@
       "dev": true,
       "requires": {
         "@babel/compat-data": "^7.10.4",
-        "browserslist": "^4.12.0",
+        "browserslist": "^4.16.5",
         "invariant": "^2.2.4",
         "levenary": "^1.1.1",
         "semver": "^5.5.0"
@@ -141,7 +141,7 @@
       "requires": {
         "@babel/helper-function-name": "^7.10.4",
         "@babel/types": "^7.10.5",
-        "lodash": "^4.17.19"
+        "lodash": "^4.17.21"
       }
     },
     "@babel/helper-explode-assignable-expression": {
@@ -212,7 +212,7 @@
         "@babel/helper-split-export-declaration": "^7.11.0",
         "@babel/template": "^7.10.4",
         "@babel/types": "^7.11.0",
-        "lodash": "^4.17.19"
+        "lodash": "^4.17.21"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -236,7 +236,7 @@
       "integrity": "sha512-68kdUAzDrljqBrio7DYAEgCoJHxppJOERHOgOrDN7WjOzP0ZQ1LsSDRXcemzVZaLvjaJsJEESb6qt+znNuENDg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.19"
+        "lodash": "^4.17.21"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -1003,7 +1003,7 @@
         "@babel/plugin-transform-unicode-regex": "^7.10.4",
         "@babel/preset-modules": "^0.1.3",
         "@babel/types": "^7.11.5",
-        "browserslist": "^4.12.0",
+        "browserslist": "^4.16.5",
         "core-js-compat": "^3.6.2",
         "invariant": "^2.2.2",
         "levenary": "^1.1.1",
@@ -1057,7 +1057,7 @@
         "@babel/types": "^7.11.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.19"
+        "lodash": "^4.17.21"
       },
       "dependencies": {
         "debug": {
@@ -1084,7 +1084,7 @@
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -1127,12 +1127,12 @@
         "@cosmjs/encoding": "^0.22.3",
         "@cosmjs/math": "^0.22.3",
         "@cosmjs/utils": "^0.22.3",
-        "axios": "^0.19.0"
+        "axios": "^0.21.2"
       },
       "dependencies": {
         "axios": {
           "version": "0.19.2",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.2.tgz",
           "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
           "requires": {
             "follow-redirects": "1.5.10"
@@ -1200,7 +1200,7 @@
       "requires": {
         "cssnano": "^4.0.0",
         "cssnano-preset-default": "^4.0.0",
-        "postcss": "^7.0.0"
+        "postcss": "^7.0.36"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -1285,10 +1285,10 @@
       "requires": {
         "@cosmjs/encoding": "^0.22.3",
         "@cosmjs/launchpad": "^0.22.2",
-        "axios": "^0.20.0",
+        "axios": "^0.21.2",
         "bip39": "^3.0.2",
         "core-js": "^3.6.5",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
         "vue": "^2.6.11",
         "vue-router": "^3.2.0",
         "vuex": "^3.4.0"
@@ -1748,7 +1748,7 @@
         "acorn-walk": "^7.1.1",
         "address": "^1.1.2",
         "autoprefixer": "^9.8.6",
-        "browserslist": "^4.12.0",
+        "browserslist": "^4.16.5",
         "cache-loader": "^4.1.0",
         "case-sensitive-paths-webpack-plugin": "^2.3.0",
         "cli-highlight": "^2.1.4",
@@ -1978,7 +1978,7 @@
         "hash-sum": "^1.0.2",
         "lru-cache": "^4.1.2",
         "merge-source-map": "^1.1.0",
-        "postcss": "^7.0.14",
+        "postcss": "^7.0.36",
         "postcss-selector-parser": "^6.0.2",
         "prettier": "^1.18.2",
         "source-map": "~0.6.1",
@@ -2289,8 +2289,8 @@
       "dev": true
     },
     "ansi-html": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.8.tgz",
       "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
       "dev": true
     },
@@ -2458,7 +2458,7 @@
       "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.14"
+        "lodash": "^4.17.21"
       }
     },
     "async-each": {
@@ -2491,12 +2491,12 @@
       "integrity": "sha512-XrvP4VVHdRBCdX1S3WXVD8+RyG9qeb1D5Sn1DeLiG2xfSpzellk5k54xbUERJ3M5DggQxes39UGOTP8CFrEGbg==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.12.0",
+        "browserslist": "^4.16.5",
         "caniuse-lite": "^1.0.30001109",
         "colorette": "^1.2.1",
         "normalize-range": "^0.1.2",
         "num2fraction": "^1.2.2",
-        "postcss": "^7.0.32",
+        "postcss": "^7.0.36",
         "postcss-value-parser": "^4.1.0"
       }
     },
@@ -2513,8 +2513,8 @@
       "dev": true
     },
     "axios": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.2.tgz",
       "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
       "requires": {
         "follow-redirects": "^1.10.0"
@@ -2856,7 +2856,7 @@
         "browserify-rsa": "^4.0.1",
         "create-hash": "^1.2.0",
         "create-hmac": "^1.1.7",
-        "elliptic": "^6.5.3",
+        "elliptic": "^6.5.4",
         "inherits": "^2.0.4",
         "parse-asn1": "^5.1.5",
         "readable-stream": "^3.6.0",
@@ -2881,8 +2881,8 @@
       }
     },
     "browserslist": {
-      "version": "4.14.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.5.tgz",
+      "version": "4.16.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.5.tgz",
       "integrity": "sha512-Z+vsCZIvCBvqLoYkBFTwEYH3v5MCQbsAjp50ERycpOjnPmolg1Gjy4+KaWWpm8QOJt9GHkhdqAl14NpCX73CWA==",
       "dev": true,
       "requires": {
@@ -2957,9 +2957,9 @@
         "move-concurrently": "^1.0.1",
         "promise-inflight": "^1.0.1",
         "rimraf": "^2.6.3",
-        "ssri": "^6.0.1",
+        "ssri": "^6.0.2",
         "unique-filename": "^1.1.1",
-        "y18n": "^4.0.0"
+        "y18n": "^4.0.1"
       }
     },
     "cache-base": {
@@ -3116,7 +3116,7 @@
       "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.0.0",
+        "browserslist": "^4.16.5",
         "caniuse-lite": "^1.0.0",
         "lodash.memoize": "^4.1.2",
         "lodash.uniq": "^4.5.0"
@@ -3167,7 +3167,7 @@
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
         "fsevents": "~2.1.2",
-        "glob-parent": "~5.1.0",
+        "glob-parent": "^5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
@@ -3299,7 +3299,7 @@
       "dev": true,
       "requires": {
         "chalk": "^3.0.0",
-        "highlight.js": "^9.6.0",
+        "highlight.js": "^10.4.1",
         "mz": "^2.4.0",
         "parse5": "^5.1.1",
         "parse5-htmlparser2-tree-adapter": "^5.1.1",
@@ -3449,7 +3449,7 @@
       "dev": true,
       "requires": {
         "color-convert": "^1.9.1",
-        "color-string": "^1.5.4"
+        "color-string": "^1.5.5"
       }
     },
     "color-convert": {
@@ -3468,8 +3468,8 @@
       "dev": true
     },
     "color-string": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.4.tgz",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.5.tgz",
       "integrity": "sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==",
       "dev": true,
       "requires": {
@@ -3714,7 +3714,7 @@
       "requires": {
         "cacache": "^12.0.3",
         "find-cache-dir": "^2.1.0",
-        "glob-parent": "^3.1.0",
+        "glob-parent": "^5.1.2",
         "globby": "^7.1.1",
         "is-glob": "^4.0.1",
         "loader-utils": "^1.2.3",
@@ -3727,8 +3727,8 @@
       },
       "dependencies": {
         "glob-parent": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
@@ -3791,7 +3791,7 @@
       "integrity": "sha512-7ItTKOhOZbznhXAQ2g/slGg1PJV5zDO/WdkTwi7UEOJmkvsE32PWvx6mKtDjiMpjnR2CNf6BAD6sSxIlv7ptng==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.8.5",
+        "browserslist": "^4.16.5",
         "semver": "7.0.0"
       },
       "dependencies": {
@@ -3840,7 +3840,7 @@
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
-        "elliptic": "^6.5.3"
+        "elliptic": "^6.5.4"
       }
     },
     "create-hash": {
@@ -3912,7 +3912,7 @@
       "integrity": "sha512-BcxQSKTSEEQUftYpBVnsH4SF05NTuBokb19/sBt6asXGKZ/6VP7PLG1CBCkFDYOnhXhPh0jMhO6xZ71oYHXHBA==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.1",
+        "postcss": "^7.0.36",
         "timsort": "^0.3.0"
       }
     },
@@ -3927,7 +3927,7 @@
         "icss-utils": "^4.1.1",
         "loader-utils": "^1.2.3",
         "normalize-path": "^3.0.0",
-        "postcss": "^7.0.32",
+        "postcss": "^7.0.36",
         "postcss-modules-extract-imports": "^2.0.0",
         "postcss-modules-local-by-default": "^3.0.2",
         "postcss-modules-scope": "^2.2.0",
@@ -4008,7 +4008,7 @@
         "cosmiconfig": "^5.0.0",
         "cssnano-preset-default": "^4.0.7",
         "is-resolvable": "^1.0.0",
-        "postcss": "^7.0.0"
+        "postcss": "^7.0.36"
       }
     },
     "cssnano-preset-default": {
@@ -4019,7 +4019,7 @@
       "requires": {
         "css-declaration-sorter": "^4.0.1",
         "cssnano-util-raw-cache": "^4.0.1",
-        "postcss": "^7.0.0",
+        "postcss": "^7.0.36",
         "postcss-calc": "^7.0.1",
         "postcss-colormin": "^4.0.3",
         "postcss-convert-values": "^4.0.1",
@@ -4067,7 +4067,7 @@
       "integrity": "sha512-qLuYtWK2b2Dy55I8ZX3ky1Z16WYsx544Q0UWViebptpwn/xDBmog2TLg4f+DBMg1rJ6JDWtn96WHbOKDWt1WQA==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.0"
+        "postcss": "^7.0.36"
       }
     },
     "cssnano-util-same-parent": {
@@ -4449,8 +4449,8 @@
       "dev": true
     },
     "dns-packet": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.2.tgz",
       "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
       "dev": true,
       "requires": {
@@ -4631,8 +4631,8 @@
       "dev": true
     },
     "elliptic": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
       "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
       "requires": {
         "bn.js": "^4.4.0",
@@ -5126,15 +5126,15 @@
       "requires": {
         "@mrmlnc/readdir-enhanced": "^2.2.1",
         "@nodelib/fs.stat": "^1.1.2",
-        "glob-parent": "^3.1.0",
+        "glob-parent": "^5.1.2",
         "is-glob": "^4.0.0",
         "merge2": "^1.2.3",
         "micromatch": "^3.1.10"
       },
       "dependencies": {
         "glob-parent": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
@@ -5538,8 +5538,8 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
       "dev": true,
       "optional": true,
@@ -5735,8 +5735,8 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "9.18.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.3.tgz",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
       "integrity": "sha512-zBZAmhSupHIl5sITeMqIJnYCDfAEc3Gdkqj65wC1lpI468MMQeeQkhcIAvk+RylAkxrCcI9xy9piHiXeQ1BdzQ==",
       "dev": true
     },
@@ -5757,8 +5757,8 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
       "dev": true
     },
@@ -5867,7 +5867,7 @@
       "requires": {
         "html-minifier": "^3.2.3",
         "loader-utils": "^0.2.16",
-        "lodash": "^4.17.3",
+        "lodash": "^4.17.21",
         "pretty-error": "^2.0.2",
         "tapable": "^1.0.0",
         "toposort": "^1.0.0",
@@ -5984,7 +5984,7 @@
       "requires": {
         "http-proxy": "^1.17.0",
         "is-glob": "^4.0.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.21",
         "micromatch": "^3.1.10"
       }
     },
@@ -6026,7 +6026,7 @@
       "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.14"
+        "postcss": "^7.0.36"
       }
     },
     "ieee754": {
@@ -6424,8 +6424,8 @@
       "dev": true
     },
     "is-svg": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-3.0.0.tgz",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-4.2.2.tgz",
       "integrity": "sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==",
       "dev": true,
       "requires": {
@@ -6734,8 +6734,8 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash.defaultsdeep": {
@@ -7180,7 +7180,7 @@
       "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
       "dev": true,
       "requires": {
-        "dns-packet": "^1.3.1",
+        "dns-packet": "^1.3.2",
         "thunky": "^1.0.2"
       }
     },
@@ -7354,7 +7354,7 @@
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
+        "hosted-git-info": "^2.8.9",
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
@@ -7655,7 +7655,7 @@
       "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
       "dev": true,
       "requires": {
-        "url-parse": "^1.4.3"
+        "url-parse": "^1.5.2"
       }
     },
     "os-browserify": {
@@ -7859,8 +7859,8 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
@@ -7986,8 +7986,8 @@
       "dev": true
     },
     "postcss": {
-      "version": "7.0.35",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
+      "version": "7.0.36",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
       "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
       "dev": true,
       "requires": {
@@ -8019,7 +8019,7 @@
       "integrity": "sha512-1tKHutbGtLtEZF6PT4JSihCHfIVldU72mZ8SdZHIYriIZ9fh9k9aWSppaT8rHsyI3dX+KSR+W+Ix9BMY3AODrg==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.27",
+        "postcss": "^7.0.36",
         "postcss-selector-parser": "^6.0.2",
         "postcss-value-parser": "^4.0.2"
       }
@@ -8030,10 +8030,10 @@
       "integrity": "sha512-WyQFAdDZpExQh32j0U0feWisZ0dmOtPl44qYmJKkq9xFWY3p+4qnRzCHeNrkeRhwPHz9bQ3mo0/yVkaply0MNw==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.0.0",
+        "browserslist": "^4.16.5",
         "color": "^3.0.0",
         "has": "^1.0.0",
-        "postcss": "^7.0.0",
+        "postcss": "^7.0.36",
         "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
@@ -8051,7 +8051,7 @@
       "integrity": "sha512-Kisdo1y77KUC0Jmn0OXU/COOJbzM8cImvw1ZFsBgBgMgb1iL23Zs/LXRe3r+EZqM3vGYKdQ2YJVQ5VkJI+zEJQ==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.0",
+        "postcss": "^7.0.36",
         "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
@@ -8069,7 +8069,7 @@
       "integrity": "sha512-RJutN259iuRf3IW7GZyLM5Sw4GLTOH8FmsXBnv8Ab/Tc2k4SR4qbV4DNbyyY4+Sjo362SyDmW2DQ7lBSChrpkg==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.0"
+        "postcss": "^7.0.36"
       }
     },
     "postcss-discard-duplicates": {
@@ -8078,7 +8078,7 @@
       "integrity": "sha512-ZNQfR1gPNAiXZhgENFfEglF93pciw0WxMkJeVmw8eF+JZBbMD7jp6C67GqJAXVZP2BWbOztKfbsdmMp/k8c6oQ==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.0"
+        "postcss": "^7.0.36"
       }
     },
     "postcss-discard-empty": {
@@ -8087,7 +8087,7 @@
       "integrity": "sha512-B9miTzbznhDjTfjvipfHoqbWKwd0Mj+/fL5s1QOz06wufguil+Xheo4XpOnc4NqKYBCNqqEzgPv2aPBIJLox0w==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.0"
+        "postcss": "^7.0.36"
       }
     },
     "postcss-discard-overridden": {
@@ -8096,7 +8096,7 @@
       "integrity": "sha512-IYY2bEDD7g1XM1IDEsUT4//iEYCxAmP5oDSFMVU/JVvT7gh+l4fmjciLqGgwjdWpQIdb0Che2VX00QObS5+cTg==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.0"
+        "postcss": "^7.0.36"
       }
     },
     "postcss-load-config": {
@@ -8116,7 +8116,7 @@
       "dev": true,
       "requires": {
         "loader-utils": "^1.1.0",
-        "postcss": "^7.0.0",
+        "postcss": "^7.0.36",
         "postcss-load-config": "^2.0.0",
         "schema-utils": "^1.0.0"
       },
@@ -8141,7 +8141,7 @@
       "dev": true,
       "requires": {
         "css-color-names": "0.0.4",
-        "postcss": "^7.0.0",
+        "postcss": "^7.0.36",
         "postcss-value-parser": "^3.0.0",
         "stylehacks": "^4.0.0"
       },
@@ -8160,10 +8160,10 @@
       "integrity": "sha512-U7e3r1SbvYzO0Jr3UT/zKBVgYYyhAz0aitvGIYOYK5CPmkNih+WDSsS5tvPrJ8YMQYlEMvsZIiqmn7HdFUaeEQ==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.0.0",
+        "browserslist": "^4.16.5",
         "caniuse-api": "^3.0.0",
         "cssnano-util-same-parent": "^4.0.0",
-        "postcss": "^7.0.0",
+        "postcss": "^7.0.36",
         "postcss-selector-parser": "^3.0.0",
         "vendors": "^1.0.0"
       },
@@ -8187,7 +8187,7 @@
       "integrity": "sha512-j85oO6OnRU9zPf04+PZv1LYIYOprWm6IA6zkXkrJXyRveDEuQggG6tvoy8ir8ZwjLxLuGfNkCZEQG7zan+Hbtg==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.0",
+        "postcss": "^7.0.36",
         "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
@@ -8207,7 +8207,7 @@
       "requires": {
         "cssnano-util-get-arguments": "^4.0.0",
         "is-color-stop": "^1.0.0",
-        "postcss": "^7.0.0",
+        "postcss": "^7.0.36",
         "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
@@ -8226,9 +8226,9 @@
       "dev": true,
       "requires": {
         "alphanum-sort": "^1.0.0",
-        "browserslist": "^4.0.0",
+        "browserslist": "^4.16.5",
         "cssnano-util-get-arguments": "^4.0.0",
-        "postcss": "^7.0.0",
+        "postcss": "^7.0.36",
         "postcss-value-parser": "^3.0.0",
         "uniqs": "^2.0.0"
       },
@@ -8249,7 +8249,7 @@
       "requires": {
         "alphanum-sort": "^1.0.0",
         "has": "^1.0.0",
-        "postcss": "^7.0.0",
+        "postcss": "^7.0.36",
         "postcss-selector-parser": "^3.0.0"
       },
       "dependencies": {
@@ -8272,7 +8272,7 @@
       "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.5"
+        "postcss": "^7.0.36"
       }
     },
     "postcss-modules-local-by-default": {
@@ -8282,7 +8282,7 @@
       "dev": true,
       "requires": {
         "icss-utils": "^4.1.1",
-        "postcss": "^7.0.32",
+        "postcss": "^7.0.36",
         "postcss-selector-parser": "^6.0.2",
         "postcss-value-parser": "^4.1.0"
       }
@@ -8293,7 +8293,7 @@
       "integrity": "sha512-YyEgsTMRpNd+HmyC7H/mh3y+MeFWevy7V1evVhJWewmMbjDHIbZbOXICC2y+m1xI1UVfIT1HMW/O04Hxyu9oXQ==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.6",
+        "postcss": "^7.0.36",
         "postcss-selector-parser": "^6.0.0"
       }
     },
@@ -8304,7 +8304,7 @@
       "dev": true,
       "requires": {
         "icss-utils": "^4.0.0",
-        "postcss": "^7.0.6"
+        "postcss": "^7.0.36"
       }
     },
     "postcss-normalize-charset": {
@@ -8313,7 +8313,7 @@
       "integrity": "sha512-gMXCrrlWh6G27U0hF3vNvR3w8I1s2wOBILvA87iNXaPvSNo5uZAMYsZG7XjCUf1eVxuPfyL4TJ7++SGZLc9A3g==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.0"
+        "postcss": "^7.0.36"
       }
     },
     "postcss-normalize-display-values": {
@@ -8323,7 +8323,7 @@
       "dev": true,
       "requires": {
         "cssnano-util-get-match": "^4.0.0",
-        "postcss": "^7.0.0",
+        "postcss": "^7.0.36",
         "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
@@ -8343,7 +8343,7 @@
       "requires": {
         "cssnano-util-get-arguments": "^4.0.0",
         "has": "^1.0.0",
-        "postcss": "^7.0.0",
+        "postcss": "^7.0.36",
         "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
@@ -8363,7 +8363,7 @@
       "requires": {
         "cssnano-util-get-arguments": "^4.0.0",
         "cssnano-util-get-match": "^4.0.0",
-        "postcss": "^7.0.0",
+        "postcss": "^7.0.36",
         "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
@@ -8382,7 +8382,7 @@
       "dev": true,
       "requires": {
         "has": "^1.0.0",
-        "postcss": "^7.0.0",
+        "postcss": "^7.0.36",
         "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
@@ -8401,7 +8401,7 @@
       "dev": true,
       "requires": {
         "cssnano-util-get-match": "^4.0.0",
-        "postcss": "^7.0.0",
+        "postcss": "^7.0.36",
         "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
@@ -8419,8 +8419,8 @@
       "integrity": "sha512-od18Uq2wCYn+vZ/qCOeutvHjB5jm57ToxRaMeNuf0nWVHaP9Hua56QyMF6fs/4FSUnVIw0CBPsU0K4LnBPwYwg==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.0.0",
-        "postcss": "^7.0.0",
+        "browserslist": "^4.16.5",
+        "postcss": "^7.0.36",
         "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
@@ -8440,7 +8440,7 @@
       "requires": {
         "is-absolute-url": "^2.0.0",
         "normalize-url": "^3.0.0",
-        "postcss": "^7.0.0",
+        "postcss": "^7.0.36",
         "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
@@ -8458,7 +8458,7 @@
       "integrity": "sha512-tO8QIgrsI3p95r8fyqKV+ufKlSHh9hMJqACqbv2XknufqEDhDvbguXGBBqxw9nsQoXWf0qOqppziKJKHMD4GtA==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.0",
+        "postcss": "^7.0.36",
         "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
@@ -8477,7 +8477,7 @@
       "dev": true,
       "requires": {
         "cssnano-util-get-arguments": "^4.0.0",
-        "postcss": "^7.0.0",
+        "postcss": "^7.0.36",
         "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
@@ -8495,10 +8495,10 @@
       "integrity": "sha512-gKWmR5aUulSjbzOfD9AlJiHCGH6AEVLaM0AV+aSioxUDd16qXP1PCh8d1/BGVvpdWn8k/HiK7n6TjeoXN1F7DA==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.0.0",
+        "browserslist": "^4.16.5",
         "caniuse-api": "^3.0.0",
         "has": "^1.0.0",
-        "postcss": "^7.0.0"
+        "postcss": "^7.0.36"
       }
     },
     "postcss-reduce-transforms": {
@@ -8509,7 +8509,7 @@
       "requires": {
         "cssnano-util-get-match": "^4.0.0",
         "has": "^1.0.0",
-        "postcss": "^7.0.0",
+        "postcss": "^7.0.36",
         "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
@@ -8539,8 +8539,8 @@
       "integrity": "sha512-C6wyjo3VwFm0QgBy+Fu7gCYOkCmgmClghO+pjcxvrcBKtiKt0uCF+hvbMO1fyv5BMImRK90SMb+dwUnfbGd+jw==",
       "dev": true,
       "requires": {
-        "is-svg": "^3.0.0",
-        "postcss": "^7.0.0",
+        "is-svg": "^4.2.2",
+        "postcss": "^7.0.36",
         "postcss-value-parser": "^3.0.0",
         "svgo": "^1.0.0"
       },
@@ -8560,7 +8560,7 @@
       "dev": true,
       "requires": {
         "alphanum-sort": "^1.0.0",
-        "postcss": "^7.0.0",
+        "postcss": "^7.0.36",
         "uniqs": "^2.0.0"
       }
     },
@@ -9047,7 +9047,7 @@
       "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.6"
+        "path-parse": "^1.0.7"
       }
     },
     "resolve-cwd": {
@@ -9551,7 +9551,7 @@
         "faye-websocket": "~0.11.1",
         "inherits": "^2.0.3",
         "json3": "^3.3.2",
-        "url-parse": "^1.4.3"
+        "url-parse": "^1.5.2"
       },
       "dependencies": {
         "debug": {
@@ -9764,8 +9764,8 @@
       }
     },
     "ssri": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
       "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
       "dev": true,
       "requires": {
@@ -10052,8 +10052,8 @@
       "integrity": "sha512-7GlLk9JwlElY4Y6a/rmbH2MhVlTyVmiJd1PfTCqFaIBEGMYNsrO/v3SeGTdhBThLg4Z+NbOk/qFMwCa+J+3p/g==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.0.0",
-        "postcss": "^7.0.0",
+        "browserslist": "^4.16.5",
+        "postcss": "^7.0.36",
         "postcss-selector-parser": "^3.0.0"
       },
       "dependencies": {
@@ -10615,8 +10615,8 @@
       }
     },
     "url-parse": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.2.tgz",
       "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
       "dev": true,
       "requires": {
@@ -10962,7 +10962,7 @@
             "async-each": "^1.0.1",
             "braces": "^2.3.2",
             "fsevents": "^1.2.7",
-            "glob-parent": "^3.1.0",
+            "glob-parent": "^5.1.2",
             "inherits": "^2.0.3",
             "is-binary-path": "^1.0.0",
             "is-glob": "^4.0.0",
@@ -10984,8 +10984,8 @@
           }
         },
         "glob-parent": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "optional": true,
@@ -11140,10 +11140,10 @@
         "express": "^4.16.3",
         "filesize": "^3.6.1",
         "gzip-size": "^5.0.0",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "mkdirp": "^0.5.1",
         "opener": "^1.5.1",
-        "ws": "^6.0.0"
+        "ws": "^6.2.2"
       },
       "dependencies": {
         "acorn": {
@@ -11183,7 +11183,7 @@
       "integrity": "sha512-PUxZ+oSTxogFQgkTtFndEtJIPNmml7ExwufBZ9L2/Xyyd5PnOL5UreWe5ZT7IU25DSdykL9p1MLQzmLh2ljSeg==",
       "dev": true,
       "requires": {
-        "ansi-html": "0.0.7",
+        "ansi-html": "0.0.8",
         "bonjour": "^3.5.0",
         "chokidar": "^2.1.8",
         "compression": "^1.7.4",
@@ -11214,7 +11214,7 @@
         "url": "^0.11.0",
         "webpack-dev-middleware": "^3.7.2",
         "webpack-log": "^2.0.0",
-        "ws": "^6.2.1",
+        "ws": "^6.2.2",
         "yargs": "^13.3.2"
       },
       "dependencies": {
@@ -11267,7 +11267,7 @@
             "async-each": "^1.0.1",
             "braces": "^2.3.2",
             "fsevents": "^1.2.7",
-            "glob-parent": "^3.1.0",
+            "glob-parent": "^5.1.2",
             "inherits": "^2.0.3",
             "is-binary-path": "^1.0.0",
             "is-glob": "^4.0.0",
@@ -11332,8 +11332,8 @@
           }
         },
         "glob-parent": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
@@ -11519,7 +11519,7 @@
             "set-blocking": "^2.0.0",
             "string-width": "^3.0.0",
             "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
+            "y18n": "^4.0.1",
             "yargs-parser": "^13.1.2"
           }
         },
@@ -11551,7 +11551,7 @@
       "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.21"
       }
     },
     "webpack-sources": {
@@ -11672,8 +11672,8 @@
       "dev": true
     },
     "ws": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
       "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
       "dev": true,
       "requires": {
@@ -11687,8 +11687,8 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
     },
@@ -11713,7 +11713,7 @@
         "set-blocking": "^2.0.0",
         "string-width": "^4.2.0",
         "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
+        "y18n": "^4.0.1",
         "yargs-parser": "^18.1.2"
       },
       "dependencies": {


### PR DESCRIPTION
According to the dependabot alert, updated versions. For "ansi-html", it is required >= 0.0.7, but this is the last version, no updated version is available. Now I changed it to 0.0.8. If it does not work, we have to remove it from the requirements.