### PR TITLE
Fix/Qb-801 change type of FileHash from []byte to string

### DIFF
--- a/x/sds/client/cli/tx.go
+++ b/x/sds/client/cli/tx.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/hex"
 	"fmt"
+
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/auth/client/utils"
@@ -45,7 +46,8 @@ func FileUploadTxCmd(cdc *codec.Codec) *cobra.Command {
 			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
 			cliCtx := context.NewCLIContextWithInput(inBuf).WithCodec(cdc)
 
-			fileHash, err := hex.DecodeString(viper.GetString(FlagFileHash))
+			fileHash := viper.GetString(FlagFileHash)
+			_, err := hex.DecodeString(fileHash)
 			if err != nil {
 				return err
 			}

--- a/x/sds/client/rest/rest.go
+++ b/x/sds/client/rest/rest.go
@@ -2,13 +2,14 @@ package rest
 
 import (
 	"encoding/hex"
+	"net/http"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/rest"
 	"github.com/cosmos/cosmos-sdk/x/auth/client/utils"
 	"github.com/gorilla/mux"
 	regTypes "github.com/stratosnet/stratos-chain/x/register/types"
 	"github.com/stratosnet/stratos-chain/x/sds/types"
-	"net/http"
 
 	"github.com/cosmos/cosmos-sdk/client/context"
 )
@@ -59,7 +60,8 @@ func FileUploadRequestHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		fileHash, err := hex.DecodeString(req.FileHash)
+		fileHash := req.FileHash
+		_, err = hex.DecodeString(fileHash)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return

--- a/x/sds/handler.go
+++ b/x/sds/handler.go
@@ -3,6 +3,7 @@ package sds
 import (
 	"encoding/hex"
 	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stratosnet/stratos-chain/x/sds/keeper"
@@ -38,7 +39,11 @@ func handleMsgFileUpload(ctx sdk.Context, k keeper.Keeper, msg types.MsgFileUplo
 	heightReEncoded.UnmarshalJSON(heightByteArr)
 
 	fileInfo := types.NewFileInfo(heightReEncoded, msg.Reporter, msg.Uploader)
-	k.SetFileHash(ctx, msg.FileHash, fileInfo)
+	fileHashByte, err := hex.DecodeString(msg.FileHash)
+	if err != nil {
+		return nil, err
+	}
+	k.SetFileHash(ctx, fileHashByte, fileInfo)
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
@@ -46,7 +51,7 @@ func handleMsgFileUpload(ctx sdk.Context, k keeper.Keeper, msg types.MsgFileUplo
 			sdk.NewAttribute(sdk.AttributeKeySender, msg.From.String()),
 			sdk.NewAttribute(types.AttributeKeyReporter, msg.Reporter.String()),
 			sdk.NewAttribute(types.AttributeKeyUploader, msg.Uploader.String()),
-			sdk.NewAttribute(types.AttributeKeyFileHash, hex.EncodeToString(msg.FileHash)),
+			sdk.NewAttribute(types.AttributeKeyFileHash, msg.FileHash),
 		),
 		sdk.NewEvent(
 			sdk.EventTypeMessage,

--- a/x/sds/keeper/keeper.go
+++ b/x/sds/keeper/keeper.go
@@ -53,7 +53,7 @@ func (fk Keeper) GetFileInfoBytesByFileHash(ctx sdk.Context, key []byte) ([]byte
 	store := ctx.KVStore(fk.key)
 	bz := store.Get(types.FileStoreKey(key))
 	if bz == nil {
-		return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownAddress, "FileHash %s does not exist", hex.EncodeToString(types.FileStoreKey(key)))
+		return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownAddress, "FileHash %s does not exist", hex.EncodeToString(types.FileStoreKey(key))[2:])
 	}
 	return bz, nil
 }

--- a/x/sds/types/msg.go
+++ b/x/sds/types/msg.go
@@ -20,17 +20,17 @@ var (
 )
 
 type MsgFileUpload struct {
-	FileHash []byte         `json:"file_hash" yaml:"file_hash"` // hash of file
+	FileHash string         `json:"file_hash" yaml:"file_hash"` // hash of file
 	From     sdk.AccAddress `json:"from" yaml:"from"`           // wallet addr who will pay this tx
 	Reporter sdk.AccAddress `json:"reporter" yaml:"reporter"`   // p2pAddr of sp node who reports this tx
-	Uploader sdk.AccAddress `json:"uploader" yaml:"uploader`    // user who uploads the file
+	Uploader sdk.AccAddress `json:"uploader" yaml:"uploader"`   // user who uploads the file
 }
 
 // verify interface at compile time
 var _ sdk.Msg = &MsgFileUpload{}
 
 // NewMsg<Action> creates a new Msg<Action> instance
-func NewMsgUpload(fileHash []byte, from, reporter, uploader sdk.AccAddress) MsgFileUpload {
+func NewMsgUpload(fileHash string, from, reporter, uploader sdk.AccAddress) MsgFileUpload {
 	return MsgFileUpload{
 		FileHash: fileHash,
 		From:     from,


### PR DESCRIPTION
1. in MsgFileUpload, change the type of FileHash field from []byte to string
2. accordingly, change types of FileHash field in client/cli/tx, client/rest/rest and types/handler   in SDS module