### PR TITLE
fix/qb1029: fix export function for register/pot/sds module

### DIFF
--- a/x/pot/app_test.go
+++ b/x/pot/app_test.go
@@ -126,7 +126,7 @@ func TestPotVolumeReportMsgs(t *testing.T) {
 		/********************* print info *********************/
 		ctx.Logger().Info("epoch " + volumeReportMsg.Epoch.String())
 		S := k.RegisterKeeper.GetInitialGenesisStakeTotal(ctx).ToDec()
-		Pt := k.GetTotalUnissuedPrepay(ctx).Amount.ToDec()
+		Pt := k.RegisterKeeper.GetTotalUnissuedPrepay(ctx).Amount.ToDec()
 		Y := k.GetTotalConsumedUoz(volumeReportMsg.WalletVolumes).ToDec()
 		Lt := k.RegisterKeeper.GetRemainingOzoneLimit(ctx).ToDec()
 		R := S.Add(Pt).Mul(Y).Quo(Lt.Add(Y))
@@ -213,7 +213,7 @@ func TestPotVolumeReportMsgs(t *testing.T) {
 		feePoolAccAddr := supplyKeeper.GetModuleAddress(auth.FeeCollectorName)
 		lastFoundationAccBalance := bankKeeper.GetCoins(ctx, foundationAccAddr)
 		lastFeePool := bankKeeper.GetCoins(ctx, feePoolAccAddr)
-		lastUnissuedPrepay := k.GetTotalUnissuedPrepay(ctx)
+		lastUnissuedPrepay := k.RegisterKeeper.GetTotalUnissuedPrepay(ctx)
 
 		/********************* deliver tx *********************/
 
@@ -257,7 +257,7 @@ func checkResultForIncentiveTestnet(t *testing.T, ctx sdk.Context, k Keeper, cur
 	feePoolAccAddr := k.SupplyKeeper.GetModuleAddress(auth.FeeCollectorName)
 	foundationAccAddr := k.SupplyKeeper.GetModuleAddress(types.FoundationAccount)
 	newFoundationAccBalance := k.BankKeeper.GetCoins(ctx, foundationAccAddr)
-	newUnissuedPrepay := sdk.NewCoins(k.GetTotalUnissuedPrepay(ctx))
+	newUnissuedPrepay := sdk.NewCoins(k.RegisterKeeper.GetTotalUnissuedPrepay(ctx))
 
 	rewardSrcChange := lastFoundationAccBalance.
 		Sub(newFoundationAccBalance).
@@ -296,7 +296,7 @@ func checkResult(t *testing.T, ctx sdk.Context, k Keeper, currentEpoch sdk.Int,
 	feePoolAccAddr := k.SupplyKeeper.GetModuleAddress(auth.FeeCollectorName)
 	foundationAccAddr := k.SupplyKeeper.GetModuleAddress(types.FoundationAccount)
 	newFoundationAccBalance := k.BankKeeper.GetCoins(ctx, foundationAccAddr)
-	newUnissuedPrepay := sdk.NewCoins(k.GetTotalUnissuedPrepay(ctx))
+	newUnissuedPrepay := sdk.NewCoins(k.RegisterKeeper.GetTotalUnissuedPrepay(ctx))
 
 	rewardSrcChange := lastFoundationAccBalance.
 		Sub(newFoundationAccBalance).
@@ -422,7 +422,7 @@ func getInitChainer(mapp *mock.App, keeper Keeper, accountKeeper auth.AccountKee
 		validators := staking.InitGenesis(ctx, stakingKeeper, accountKeeper, supplyKeeper, stakingGenesis)
 
 		//preset
-		keeper.SetTotalUnissuedPrepay(ctx, totalUnissuedPrepay)
+		keeper.RegisterKeeper.SetTotalUnissuedPrepay(ctx, totalUnissuedPrepay)
 
 		//pot genesis data load
 		InitGenesis(ctx, keeper, NewGenesisState(types.DefaultParams()))

--- a/x/pot/keeper/distribute.go
+++ b/x/pot/keeper/distribute.go
@@ -103,12 +103,12 @@ func (k Keeper) deductRewardFromRewardProviderAccount(ctx sdk.Context, goal type
 	k.setMinedTokens(ctx, epoch, totalRewardFromMiningPool)
 
 	// deduct traffic reward from prepay pool
-	totalUnIssuedPrepay := k.GetTotalUnissuedPrepay(ctx)
+	totalUnIssuedPrepay := k.RegisterKeeper.GetTotalUnissuedPrepay(ctx)
 	newTotalUnIssuedPrePay := totalUnIssuedPrepay.Sub(totalRewardFromTrafficPool)
 	if newTotalUnIssuedPrePay.IsNegative() {
 		return types.ErrInsufficientUnissuedPrePayBalance
 	}
-	k.SetTotalUnissuedPrepay(ctx, newTotalUnIssuedPrePay)
+	k.RegisterKeeper.SetTotalUnissuedPrepay(ctx, newTotalUnIssuedPrePay)
 
 	return nil
 }
@@ -144,9 +144,9 @@ func (k Keeper) returnBalance(ctx sdk.Context, goal types.DistributeGoal, epoch 
 	k.setMinedTokens(ctx, epoch, newMinedToken)
 
 	// return balance to prepay pool
-	totalUnIssuedPrepay := k.GetTotalUnissuedPrepay(ctx)
+	totalUnIssuedPrepay := k.RegisterKeeper.GetTotalUnissuedPrepay(ctx)
 	newTotalUnIssuedPrePay := totalUnIssuedPrepay.Add(balanceOfTrafficPool)
-	k.SetTotalUnissuedPrepay(ctx, newTotalUnIssuedPrePay)
+	k.RegisterKeeper.SetTotalUnissuedPrepay(ctx, newTotalUnIssuedPrePay)
 
 	return nil
 }
@@ -192,7 +192,7 @@ func (k Keeper) getTrafficReward(ctx sdk.Context, trafficList []types.SingleWall
 	if S.Equal(sdk.ZeroDec()) {
 		ctx.Logger().Info("initial genesis deposit by all resource nodes and meta nodes is 0")
 	}
-	Pt := k.GetTotalUnissuedPrepay(ctx).Amount.ToDec()
+	Pt := k.RegisterKeeper.GetTotalUnissuedPrepay(ctx).Amount.ToDec()
 	if Pt.Equal(sdk.ZeroDec()) {
 		ctx.Logger().Info("total remaining prepay not issued is 0")
 	}

--- a/x/pot/keeper/distribute_test.go
+++ b/x/pot/keeper/distribute_test.go
@@ -105,7 +105,7 @@ func Test(t *testing.T) {
 	registerKeeper.SetInitialGenesisStakeTotal(ctx, initialGenesisStakeTotal.Amount)
 
 	//PrePay
-	k.SetTotalUnissuedPrepay(ctx, totalUnissuedPrePay)
+	registerKeeper.SetTotalUnissuedPrepay(ctx, totalUnissuedPrePay)
 	//remaining ozone limit
 	registerKeeper.SetRemainingOzoneLimit(ctx, remainingOzoneLimit)
 	//initial uoz price
@@ -185,7 +185,7 @@ func Test(t *testing.T) {
 	//check prepared data
 	S := k.RegisterKeeper.GetInitialGenesisStakeTotal(ctx).ToDec()
 	fmt.Println("S=" + S.String())
-	Pt := k.GetTotalUnissuedPrepay(ctx).Amount.ToDec()
+	Pt := registerKeeper.GetTotalUnissuedPrepay(ctx).Amount.ToDec()
 	fmt.Println("Pt=" + Pt.String())
 	Y := k.GetTotalConsumedUoz(trafficList).ToDec()
 	fmt.Println("Y=" + Y.String())
@@ -316,7 +316,7 @@ func testFullDistributeProcessAtEpoch2017(t *testing.T, ctx sdk.Context, k Keepe
 
 func testFullDistributeProcessAtEpoch1(t *testing.T, ctx sdk.Context, k Keeper, trafficList []types.SingleWalletVolume) {
 	//PrePay
-	k.SetTotalUnissuedPrepay(ctx, totalUnissuedPrePay)
+	k.RegisterKeeper.SetTotalUnissuedPrepay(ctx, totalUnissuedPrePay)
 
 	_, err := k.DistributePotReward(ctx, trafficList, epoch1)
 	require.NoError(t, err)

--- a/x/pot/keeper/incentive_testnet_distribute.go
+++ b/x/pot/keeper/incentive_testnet_distribute.go
@@ -341,9 +341,9 @@ func (k Keeper) returnBalanceForTestnet(ctx sdk.Context, goal types.DistributeGo
 	k.setMinedTokens(ctx, epoch, newMinedToken)
 
 	// return balance to prepay pool
-	totalUnIssuedPrepay := k.GetTotalUnissuedPrepay(ctx)
+	totalUnIssuedPrepay := k.RegisterKeeper.GetTotalUnissuedPrepay(ctx)
 	newTotalUnIssuedPrePay := totalUnIssuedPrepay.Add(balanceOfTrafficPool)
-	k.SetTotalUnissuedPrepay(ctx, newTotalUnIssuedPrePay)
+	k.RegisterKeeper.SetTotalUnissuedPrepay(ctx, newTotalUnIssuedPrePay)
 
 	return nil
 }

--- a/x/pot/keeper/store.go
+++ b/x/pot/keeper/store.go
@@ -37,22 +37,6 @@ func (k Keeper) GetMinedTokens(ctx sdk.Context, epoch sdk.Int) (minedToken sdk.C
 	return
 }
 
-func (k Keeper) SetTotalUnissuedPrepay(ctx sdk.Context, totalUnissuedPrepay sdk.Coin) {
-	store := ctx.KVStore(k.storeKey)
-	b := k.cdc.MustMarshalBinaryLengthPrefixed(totalUnissuedPrepay)
-	store.Set(types.TotalUnissuedPrepayKey, b)
-}
-
-func (k Keeper) GetTotalUnissuedPrepay(ctx sdk.Context) (totalUnissuedPrepay sdk.Coin) {
-	store := ctx.KVStore(k.storeKey)
-	b := store.Get(types.TotalUnissuedPrepayKey)
-	if b == nil {
-		return sdk.NewCoin(k.BondDenom(ctx), sdk.ZeroInt())
-	}
-	k.cdc.MustUnmarshalBinaryLengthPrefixed(b, &totalUnissuedPrepay)
-	return
-}
-
 func (k Keeper) setRewardAddressPool(ctx sdk.Context, walletAddressList []sdk.AccAddress) {
 	store := ctx.KVStore(k.storeKey)
 	b := k.cdc.MustMarshalBinaryLengthPrefixed(walletAddressList)

--- a/x/pot/types/key.go
+++ b/x/pot/types/key.go
@@ -19,9 +19,8 @@ const (
 )
 
 var (
-	TotalMinedTokensKey    = []byte{0x03}
-	MinedTokensKeyPrefix   = []byte{0x04} // key: prefix_epoch
-	TotalUnissuedPrepayKey = []byte{0x05}
+	TotalMinedTokensKey  = []byte{0x03}
+	MinedTokensKeyPrefix = []byte{0x04} // key: prefix_epoch
 
 	RewardAddressPoolKey         = []byte{0x11}
 	LastReportedEpochKey         = []byte{0x12}

--- a/x/register/genesis.go
+++ b/x/register/genesis.go
@@ -53,6 +53,10 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, data types.GenesisState) {
 	keeper.SetInitialUOzonePrice(ctx, initialUOzonePrice)
 	initOzoneLimit := initialStakeTotal.ToDec().Quo(initialUOzonePrice).TruncateInt()
 	keeper.SetRemainingOzoneLimit(ctx, initOzoneLimit)
+	keeper.SetTotalUnissuedPrepay(ctx, sdk.Coin{
+		Denom:  data.Params.BondDenom,
+		Amount: data.TotalUnissuedPrepay,
+	})
 }
 
 // ExportGenesis writes the current store values
@@ -75,7 +79,8 @@ func ExportGenesis(ctx sdk.Context, keeper Keeper) (data types.GenesisState) {
 
 	resourceNodes := keeper.GetAllResourceNodes(ctx)
 	indexingNodes := keeper.GetAllIndexingNodes(ctx)
-	initialUOzonePrice := keeper.GetInitialUOzonePrice(ctx)
+	totalUnissuedPrepay := keeper.GetTotalUnissuedPrepay(ctx).Amount
+	initialUOzonePrice := keeper.CurrUozPrice(ctx)
 
 	return types.GenesisState{
 		Params:                 params,
@@ -84,5 +89,6 @@ func ExportGenesis(ctx sdk.Context, keeper Keeper) (data types.GenesisState) {
 		LastIndexingNodeStakes: lastIndexingNodeStakes,
 		IndexingNodes:          indexingNodes,
 		InitialUozPrice:        initialUOzonePrice,
+		TotalUnissuedPrepay:    totalUnissuedPrepay,
 	}
 }

--- a/x/register/types/errors.go
+++ b/x/register/types/errors.go
@@ -46,4 +46,5 @@ var (
 	ErrInvalidNodeStatBonded              = sdkerrors.Register(ModuleName, 39, "invalid node status: bonded")
 	ErrInitialUOzonePrice                 = sdkerrors.Register(ModuleName, 40, "initial uOzone price must be positive")
 	ErrInvalidStakeChange                 = sdkerrors.Register(ModuleName, 41, "invalid change for stake")
+	ErrTotalUnissuedPrepay                = sdkerrors.Register(ModuleName, 42, "total unissued prepay must be non-negative")
 )

--- a/x/register/types/genesis.go
+++ b/x/register/types/genesis.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stratos "github.com/stratosnet/stratos-chain/types"
@@ -15,6 +16,7 @@ type GenesisState struct {
 	LastIndexingNodeStakes []LastIndexingNodeStake `json:"last_indexing_node_stakes" yaml:"last_indexing_node_stakes"`
 	IndexingNodes          IndexingNodes           `json:"indexing_nodes" yaml:"indexing_nodes"`
 	InitialUozPrice        sdk.Dec                 `json:"initial_uoz_price" yaml:"initial_uoz_price"` //initial price of uoz
+	TotalUnissuedPrepay    sdk.Int                 `json:"total_unissued_prepay", yaml:"total_unissued_prepay"`
 }
 
 // LastResourceNodeStake required for resource node set update logic
@@ -33,7 +35,7 @@ type LastIndexingNodeStake struct {
 func NewGenesisState(params Params,
 	lastResourceNodeStakes []LastResourceNodeStake, resourceNodes ResourceNodes,
 	lastIndexingNodeStakes []LastIndexingNodeStake, indexingNodes IndexingNodes,
-	initialUOzonePrice sdk.Dec,
+	initialUOzonePrice sdk.Dec, totalUnissuedPrepay sdk.Int,
 ) GenesisState {
 	return GenesisState{
 		Params:                 params,
@@ -42,14 +44,16 @@ func NewGenesisState(params Params,
 		LastIndexingNodeStakes: lastIndexingNodeStakes,
 		IndexingNodes:          indexingNodes,
 		InitialUozPrice:        initialUOzonePrice,
+		TotalUnissuedPrepay:    totalUnissuedPrepay,
 	}
 }
 
 // DefaultGenesisState - default GenesisState used by Cosmos Hub
 func DefaultGenesisState() GenesisState {
 	return GenesisState{
-		Params:          DefaultParams(),
-		InitialUozPrice: DefaultUozPrice,
+		Params:              DefaultParams(),
+		InitialUozPrice:     DefaultUozPrice,
+		TotalUnissuedPrepay: DefaultTotalUnissuedPrepay,
 	}
 }
 
@@ -98,6 +102,10 @@ func ValidateGenesis(data GenesisState) error {
 		}
 	}
 	if data.InitialUozPrice.LTE(sdk.ZeroDec()) {
+		return ErrInitialUOzonePrice
+	}
+
+	if data.TotalUnissuedPrepay.LT(sdk.ZeroInt()) {
 		return ErrInitialUOzonePrice
 	}
 	return nil

--- a/x/register/types/keys.go
+++ b/x/register/types/keys.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // Bech32PubKeyType defines a string type alias for a Bech32 public key type.
@@ -26,6 +27,7 @@ var (
 	IndexingNodeNotBondedTokenKey = []byte{0x03}
 	IndexingNodeBondedTokenKey    = []byte{0x04}
 	UpperBoundOfTotalOzoneKey     = []byte{0x05}
+	TotalUnissuedPrepayKey        = []byte{0x06}
 
 	LastResourceNodeStakeKey    = []byte{0x11} // prefix for each key to a resource node index, for bonded resource nodes
 	LastIndexingNodeStakeKey    = []byte{0x12} // prefix for each key to a indexing node index, for bonded indexing nodes

--- a/x/register/types/params.go
+++ b/x/register/types/params.go
@@ -27,7 +27,8 @@ var (
 	KeyUnbondingCompletionTime = []byte("UnbondingCompletionTime")
 	KeyMaxEntries              = []byte("KeyMaxEntries")
 
-	DefaultUozPrice = sdk.NewDecWithPrec(1000000, 9) // 0.001 ustos -> 1 uoz
+	DefaultUozPrice            = sdk.NewDecWithPrec(1000000, 9) // 0.001 ustos -> 1 uoz
+	DefaultTotalUnissuedPrepay = sdk.NewInt(0)
 )
 
 var _ subspace.ParamSet = &Params{}

--- a/x/sds/genesis.go
+++ b/x/sds/genesis.go
@@ -13,10 +13,6 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, data types.GenesisState) {
 	for _, file := range data.FileUpload {
 		keeper.SetFileHash(ctx, []byte(file.FileHash), file.FileInfo)
 	}
-
-	for _, p := range data.Prepay {
-		keeper.SetPrepay(ctx, p.Sender, p.Coins)
-	}
 }
 
 // ExportGenesis writes the current store values
@@ -31,14 +27,5 @@ func ExportGenesis(ctx sdk.Context, keeper Keeper) (data types.GenesisState) {
 		return false
 	})
 
-	var prepay []types.Prepay
-	keeper.IteratePrepay(ctx, func(sender sdk.AccAddress, amt sdk.Int) (stop bool) {
-		coins := sdk.NewCoins(sdk.Coin{
-			Denom:  params.BondDenom,
-			Amount: amt,
-		})
-		prepay = append(prepay, types.Prepay{Sender: sender, Coins: coins})
-		return false
-	})
-	return types.NewGenesisState(params, fileUpload, prepay)
+	return types.NewGenesisState(params, fileUpload)
 }

--- a/x/sds/keeper/keeper.go
+++ b/x/sds/keeper/keeper.go
@@ -81,7 +81,7 @@ func (k Keeper) SetFileHash(ctx sdk.Context, fileHash []byte, fileInfo types.Fil
 // the total amount of Ozone the user gets = Lt * X / (S + Pt + X)
 func (k Keeper) purchaseUoz(ctx sdk.Context, amount sdk.Int) sdk.Int {
 	S := k.RegisterKeeper.GetInitialGenesisStakeTotal(ctx)
-	Pt := k.PotKeeper.GetTotalUnissuedPrepay(ctx).Amount
+	Pt := k.RegisterKeeper.GetTotalUnissuedPrepay(ctx).Amount
 	Lt := k.RegisterKeeper.GetRemainingOzoneLimit(ctx)
 
 	purchased := Lt.ToDec().
@@ -93,7 +93,7 @@ func (k Keeper) purchaseUoz(ctx sdk.Context, amount sdk.Int) sdk.Int {
 
 	// update total unissued prepay
 	newTotalUnissuedPrepay := Pt.Add(amount)
-	k.PotKeeper.SetTotalUnissuedPrepay(ctx, sdk.NewCoin(k.BondDenom(ctx), newTotalUnissuedPrepay))
+	k.RegisterKeeper.SetTotalUnissuedPrepay(ctx, sdk.NewCoin(k.BondDenom(ctx), newTotalUnissuedPrepay))
 
 	// update remaining uoz limit
 	newRemainingOzoneLimit := Lt.Sub(purchased)
@@ -104,7 +104,7 @@ func (k Keeper) purchaseUoz(ctx sdk.Context, amount sdk.Int) sdk.Int {
 
 func (k Keeper) simulatePurchaseUoz(ctx sdk.Context, amount sdk.Int) sdk.Int {
 	S := k.RegisterKeeper.GetInitialGenesisStakeTotal(ctx)
-	Pt := k.PotKeeper.GetTotalUnissuedPrepay(ctx).Amount
+	Pt := k.RegisterKeeper.GetTotalUnissuedPrepay(ctx).Amount
 	Lt := k.RegisterKeeper.GetRemainingOzoneLimit(ctx)
 	purchased := Lt.ToDec().
 		Mul(amount.ToDec()).
@@ -113,25 +113,6 @@ func (k Keeper) simulatePurchaseUoz(ctx sdk.Context, amount sdk.Int) sdk.Int {
 			Add(amount)).ToDec()).
 		TruncateInt()
 	return purchased
-}
-
-// calc current uoz price
-func (k Keeper) currUozPrice(ctx sdk.Context) sdk.Dec {
-	S := k.RegisterKeeper.GetInitialGenesisStakeTotal(ctx)
-	Pt := k.PotKeeper.GetTotalUnissuedPrepay(ctx).Amount
-	Lt := k.RegisterKeeper.GetRemainingOzoneLimit(ctx)
-	currUozPrice := (S.Add(Pt)).ToDec().
-		Quo(Lt.ToDec())
-	return currUozPrice
-}
-
-// calc remaining/total supply for uoz
-func (k Keeper) uozSupply(ctx sdk.Context) (remaining, total sdk.Int) {
-	remaining = k.RegisterKeeper.GetRemainingOzoneLimit(ctx)
-	// TODO create a dedicated storeKey in pot module for total ozone supply and keep updating it along with related operations (like AddResourceNodeStake)
-	// fake return of total
-	total, _ = sdk.NewIntFromString("-1")
-	return remaining, total
 }
 
 // Prepay transfers coins from bank to sds (volumn) pool

--- a/x/sds/keeper/keeper.go
+++ b/x/sds/keeper/keeper.go
@@ -263,7 +263,6 @@ func (k Keeper) IteratePrepay(ctx sdk.Context, handler func(sdk.AccAddress, sdk.
 		if err != nil {
 			panic("invalid prepay amount")
 		}
-		//k.cdc.MustUnmarshalBinaryLengthPrefixed(iter.Value(), &amt)
 		if handler(senderAddr, amt) {
 			break
 		}

--- a/x/sds/keeper/querier.go
+++ b/x/sds/keeper/querier.go
@@ -72,7 +72,7 @@ func querySimulatePrepay(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]by
 
 // queryCurrUozPrice fetch current uoz price.
 func queryCurrUozPrice(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte, error) {
-	uozPrice := k.currUozPrice(ctx)
+	uozPrice := k.RegisterKeeper.CurrUozPrice(ctx)
 	uozPriceByte, _ := uozPrice.MarshalJSON()
 	return uozPriceByte, nil
 }
@@ -84,7 +84,7 @@ func queryUozSupply(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte, e
 		Total     sdk.Int
 	}
 	var uozSupply Supply
-	uozSupply.Remaining, uozSupply.Total = k.uozSupply(ctx)
+	uozSupply.Remaining, uozSupply.Total = k.RegisterKeeper.UozSupply(ctx)
 	uozSupplyByte, _ := json.Marshal(uozSupply)
 	return uozSupplyByte, nil
 }

--- a/x/sds/types/errors.go
+++ b/x/sds/types/errors.go
@@ -5,5 +5,11 @@ import (
 )
 
 var (
-	ErrInvalid = sdkerrors.Register(ModuleName, 1, "error invalid")
+	ErrInvalid           = sdkerrors.Register(ModuleName, 1, "error invalid")
+	ErrInvalidHeight     = sdkerrors.Register(ModuleName, 2, "invalid height")
+	ErrEmptyUploaderAddr = sdkerrors.Register(ModuleName, 3, "missing uploader address")
+	ErrEmptyReporterAddr = sdkerrors.Register(ModuleName, 4, "missing reporter address")
+	ErrEmptyFileHash     = sdkerrors.Register(ModuleName, 5, "missing file hash")
+	ErrEmptySenderAddr   = sdkerrors.Register(ModuleName, 6, "missing sender address")
+	ErrInvalidCoins      = sdkerrors.Register(ModuleName, 7, "invalid coins")
 )

--- a/x/sds/types/genesis.go
+++ b/x/sds/types/genesis.go
@@ -11,7 +11,6 @@ import (
 type GenesisState struct {
 	Params     Params       `json:"params" yaml:"params"`
 	FileUpload []FileUpload `json:"file_upload" yaml:"file_upload"`
-	Prepay     []Prepay     `json:"prepay" yaml:"prepay"`
 }
 
 // FileUpload required for fileInfo set update logic
@@ -20,18 +19,11 @@ type FileUpload struct {
 	FileInfo FileInfo `json:"file_info" yaml:"file_info"`
 }
 
-// Prepay required for prepay set update logic
-type Prepay struct {
-	Sender sdk.AccAddress `json:"sender" yaml:"sender"`
-	Coins  sdk.Coins      `json:"coins" yaml:"coins"`
-}
-
 // NewGenesisState creates a new GenesisState object
-func NewGenesisState(params Params, fileUpload []FileUpload, prepay []Prepay) GenesisState {
+func NewGenesisState(params Params, fileUpload []FileUpload) GenesisState {
 	return GenesisState{
 		Params:     params,
 		FileUpload: fileUpload,
-		Prepay:     prepay,
 	}
 }
 
@@ -72,17 +64,6 @@ func ValidateGenesis(data GenesisState) error {
 			}
 			if upload.FileInfo.Uploader.Empty() {
 				return ErrEmptyUploaderAddr
-			}
-		}
-	}
-
-	if len(data.Prepay) > 0 {
-		for _, p := range data.Prepay {
-			if p.Sender.Empty() {
-				return ErrEmptySenderAddr
-			}
-			if !p.Coins.IsValid() {
-				return ErrInvalidHeight
 			}
 		}
 	}

--- a/x/sds/types/genesis.go
+++ b/x/sds/types/genesis.go
@@ -1,14 +1,37 @@
 package types
 
+import (
+	"encoding/json"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
 // GenesisState - all sds state that must be provided at genesis
 type GenesisState struct {
-	Params Params `json:"params" yaml:"params"`
+	Params     Params       `json:"params" yaml:"params"`
+	FileUpload []FileUpload `json:"file_upload" yaml:"file_upload"`
+	Prepay     []Prepay     `json:"prepay" yaml:"prepay"`
+}
+
+// FileUpload required for fileInfo set update logic
+type FileUpload struct {
+	FileHash string   `json:"file_hash" yaml:"file_hash"`
+	FileInfo FileInfo `json:"file_info" yaml:"file_info"`
+}
+
+// Prepay required for prepay set update logic
+type Prepay struct {
+	Sender sdk.AccAddress `json:"sender" yaml:"sender"`
+	Coins  sdk.Coins      `json:"coins" yaml:"coins"`
 }
 
 // NewGenesisState creates a new GenesisState object
-func NewGenesisState(params Params) GenesisState {
+func NewGenesisState(params Params, fileUpload []FileUpload, prepay []Prepay) GenesisState {
 	return GenesisState{
-		Params: params,
+		Params:     params,
+		FileUpload: fileUpload,
+		Prepay:     prepay,
 	}
 }
 
@@ -19,8 +42,49 @@ func DefaultGenesisState() GenesisState {
 	}
 }
 
+// GetGenesisStateFromAppState returns x/auth GenesisState given raw application
+// genesis state.
+func GetGenesisStateFromAppState(cdc *codec.Codec, appState map[string]json.RawMessage) GenesisState {
+	var genesisState GenesisState
+	if appState[ModuleName] != nil {
+		cdc.MustUnmarshalJSON(appState[ModuleName], &genesisState)
+	}
+
+	return genesisState
+}
+
 // ValidateGenesis validates the sds genesis parameters
 func ValidateGenesis(data GenesisState) error {
-	// TODO: Create a sanity check to make sure the state conforms to the modules needs
+	if err := data.Params.ValidateBasic(); err != nil {
+		return err
+	}
+
+	if len(data.FileUpload) > 0 {
+		for _, upload := range data.FileUpload {
+			if len(upload.FileHash) == 0 {
+				return ErrEmptyFileHash
+			}
+			if upload.FileInfo.Height.LT(sdk.ZeroInt()) {
+				return ErrInvalidHeight
+			}
+			if upload.FileInfo.Reporter.Empty() {
+				return ErrEmptyReporterAddr
+			}
+			if upload.FileInfo.Uploader.Empty() {
+				return ErrEmptyUploaderAddr
+			}
+		}
+	}
+
+	if len(data.Prepay) > 0 {
+		for _, p := range data.Prepay {
+			if p.Sender.Empty() {
+				return ErrEmptySenderAddr
+			}
+			if !p.Coins.IsValid() {
+				return ErrInvalidHeight
+			}
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
- qb1029: move TotalUnissuedPrepay from pot to register
- qb1029: export currUozPrice instead of initalUozPrice into new genesis of register
- qb1029: TotalUnissuedPrepay added to genesis
- qb1029: uozSupply api can now correctly return total supply