### PR TITLE
Feat/QB-1061: finish the slashing deduction logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,5 +18,5 @@ require (
 	github.com/tendermint/tendermint v0.33.9
 	github.com/tendermint/tm-db v0.5.1
 	golang.org/x/sys v0.0.0-20220315194320-039c03cc5b86 // indirect
-	gopkg.in/yaml.v2 v2.3.0 // indirect
+	gopkg.in/yaml.v2 v2.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -596,10 +596,7 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201013132646-2da7054afaeb h1:HS9IzC4UFbpMBLQUDSQcU+ViVT1vdFCQVjdPVpTlZrs=
 golang.org/x/sys v0.0.0-20201013132646-2da7054afaeb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 h1:XfKQ4OlFl8okEOr5UvAqFRVj8pY/4yfcXrddB8qAbU0=
-golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220315194320-039c03cc5b86 h1:A9i04dxx7Cribqbs8jf3FQLogkL/CV2YN7hj9KWJCkc=
 golang.org/x/sys v0.0.0-20220315194320-039c03cc5b86/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/x/pot/app_test.go
+++ b/x/pot/app_test.go
@@ -389,15 +389,12 @@ func checkResult(t *testing.T, ctx sdk.Context, k Keeper, registerKeeper registe
 
 	individualRewardTotal := sdk.Coins{}
 	newMatureEpoch := currentEpoch.Add(sdk.NewInt(k.MatureEpoch(ctx)))
-	rewardAddrList := k.GetRewardAddressPool(ctx)
-	for _, addr := range rewardAddrList {
-		individualReward, found := k.GetIndividualReward(ctx, addr, newMatureEpoch)
-		if found {
-			individualRewardTotal = individualRewardTotal.Add(individualReward.RewardFromTrafficPool...).Add(individualReward.RewardFromMiningPool...)
-		}
 
-		ctx.Logger().Info("individualReward of [" + addr.String() + "] = " + individualReward.String())
-	}
+	k.IteratorIndividualReward(ctx, newMatureEpoch, func(walletAddress sdk.AccAddress, individualReward types.Reward) (stop bool) {
+		individualRewardTotal = individualRewardTotal.Add(individualReward.RewardFromTrafficPool...).Add(individualReward.RewardFromMiningPool...)
+		ctx.Logger().Info("individualReward of [" + walletAddress.String() + "] = " + individualReward.String())
+		return false
+	})
 
 	feePoolAccAddr := k.SupplyKeeper.GetModuleAddress(auth.FeeCollectorName)
 	foundationAccAddr := k.SupplyKeeper.GetModuleAddress(types.FoundationAccount)

--- a/x/pot/app_test.go
+++ b/x/pot/app_test.go
@@ -42,7 +42,14 @@ func setupMsgVolumeReport(newEpoch int64) types.MsgVolumeReport {
 	reportReference := "report for epoch " + epoch.String()
 	reporterOwner := idxOwner1
 
-	volumeReportMsg := types.NewMsgVolumeReport(nodesVolume, reporter, epoch, reportReference, reporterOwner, types.BLSSignatureInfo{})
+	pubKeys := make([][]byte, 1)
+	for i := range pubKeys {
+		pubKeys[i] = make([]byte, 1)
+	}
+
+	signature := types.NewBLSSignatureInfo(pubKeys, []byte("signature"), []byte("txData"))
+
+	volumeReportMsg := types.NewMsgVolumeReport(nodesVolume, reporter, epoch, reportReference, reporterOwner, signature)
 
 	return volumeReportMsg
 }
@@ -50,12 +57,10 @@ func setupMsgVolumeReport(newEpoch int64) types.MsgVolumeReport {
 func setupSlashingMsg() types.MsgSlashingResourceNode {
 	reporters := make([]stratos.SdsAddress, 0)
 	reporters = append(reporters, idxNodeNetworkId1)
-	reporters = append(reporters, idxNodeNetworkId2)
 	reportOwner := make([]sdk.AccAddress, 0)
 	reportOwner = append(reportOwner, idxOwner1)
-	reportOwner = append(reportOwner, idxOwner2)
 
-	slashingMsg := types.NewMsgSlashingResourceNode(reporters, reportOwner, resNodeNetworkId1, resOwner1, sdk.NewInt(100000000000000000), true)
+	slashingMsg := types.NewMsgSlashingResourceNode(reporters, reportOwner, resNodeNetworkId1, resOwner1, resNodeSlashingUOZAmt1, true)
 	return slashingMsg
 }
 
@@ -77,10 +82,8 @@ func isNeedStop(ctx sdk.Context, k Keeper, epoch sdk.Int, minedToken sdk.Coin) b
 }
 
 func TestPotVolumeReportMsgs(t *testing.T) {
-
 	/********************* initialize mock app *********************/
-	//mApp, k, accountKeeper, bankKeeper, stakingKeeper, registerKeeper := getMockApp(t)
-	mApp, k, stakingKeeper, bankKeeper, supplyKeeper := getMockApp(t)
+	mApp, k, stakingKeeper, bankKeeper, supplyKeeper, registerKeeper := getMockApp(t)
 	accs := setupAccounts(mApp)
 	mock.SetGenesis(mApp, accs)
 
@@ -123,12 +126,14 @@ func TestPotVolumeReportMsgs(t *testing.T) {
 
 	/********************** loop sending volume report **********************/
 	var i int64
+	var slashingAmtSetup sdk.Int
 	i = 0
+	slashingAmtSetup = sdk.ZeroInt()
 	for {
 
 		/********************* test slashing msg when i==2 *********************/
 		if i == 2 {
-			ctx.Logger().Info("*****************************************************************************")
+			ctx.Logger().Info("********************************* Deliver Slashing Tx START ********************************************")
 			slashingMsg := setupSlashingMsg()
 			/********************* deliver tx *********************/
 
@@ -140,6 +145,17 @@ func TestPotVolumeReportMsgs(t *testing.T) {
 			/********************* commit & check result *********************/
 			header = abci.Header{Height: mApp.LastBlockHeight() + 1}
 			ctx = mApp.BaseApp.NewContext(true, header)
+
+			slashingAmtSetup = registerKeeper.GetSlashing(ctx, resOwner1)
+
+			_, slashingAmtCheck := k.GetTrafficReward(ctx, []types.SingleWalletVolume{{
+				WalletAddress: resOwner1,
+				Volume:        resNodeSlashingUOZAmt1,
+			}})
+			println("slashingAmtSetup=" + slashingAmtSetup.String())
+			require.Equal(t, slashingAmtSetup, slashingAmtCheck.TruncateInt())
+
+			ctx.Logger().Info("********************************* Deliver Slashing Tx END ********************************************")
 		}
 
 		ctx.Logger().Info("*****************************************************************************")
@@ -169,40 +185,40 @@ func TestPotVolumeReportMsgs(t *testing.T) {
 
 		//TODO: recovery when shift to main net
 		/********************************************************** Main net part Start *********************************************************************/
-		//distributeGoal, err = k.CalcMiningRewardInTotal(ctx, distributeGoal) //for main net
-		//require.NoError(t, err)
-		//ctx.Logger().Info(distributeGoal.String())
-		//
-		//ctx.Logger().Info("---------------------------")
-		//distributeGoalBalance := distributeGoal
-		//rewardDetailMap := make(map[string]types.Reward)
-		//rewardDetailMap, distributeGoalBalance = k.CalcRewardForResourceNode(ctx, volumeReportMsg.WalletVolumes, distributeGoalBalance, rewardDetailMap)
+		distributeGoal, err = k.CalcMiningRewardInTotal(ctx, distributeGoal) //for main net
+		require.NoError(t, err)
+		ctx.Logger().Info(distributeGoal.String())
+
+		ctx.Logger().Info("---------------------------")
+		distributeGoalBalance := distributeGoal
+		rewardDetailMap := make(map[string]types.Reward)
+		rewardDetailMap, distributeGoalBalance = k.CalcRewardForResourceNode(ctx, volumeReportMsg.WalletVolumes, distributeGoalBalance, rewardDetailMap)
 		/********************************************************** Main net part End *********************************************************************/
 
 		//TODO: remove when shift to main net
 		/********************************************************** Incentive testnet part Start *********************************************************************/
-		distributeGoal, idxNodeCnt, resNodeCnt, err := k.CalcMiningRewardInTotalForTestnet(ctx, distributeGoal) //for incentive test net
-		require.NoError(t, err)
-		ctx.Logger().Info(distributeGoal.String())
-		ctx.Logger().Info("---------------------------")
-		distributeGoalBalance := distributeGoal
-		rewardDetailMap := make(map[string]types.Reward)
-
-		rewardDetailMap, distributeGoalBalance = k.CalcRewardForResourceNodeForTestnet(ctx, volumeReportMsg.WalletVolumes, distributeGoalBalance, rewardDetailMap, resNodeCnt)
-		rewardDetailMap, distributeGoalBalance = k.CalcRewardForIndexingNodeForTestnet(ctx, distributeGoalBalance, rewardDetailMap, idxNodeCnt)
-
-		//calc mining reward to distribute to validators
-		rewardFromMiningPool := distributeGoal.BlockChainRewardToValidatorFromMiningPool
-		usedRewardFromMiningPool := sdk.NewCoin(k.RewardDenom(ctx), sdk.ZeroInt())
-		validatorWalletList := make([]sdk.AccAddress, 0)
-		validators := k.StakingKeeper.GetAllValidators(ctx)
-		for _, validator := range validators {
-			if validator.IsBonded() && !validator.IsJailed() {
-				validatorWalletList = append(validatorWalletList, sdk.AccAddress(validator.GetOperator()))
-			}
-		}
-		rewardPerValidator := sdk.NewCoin(k.RewardDenom(ctx), rewardFromMiningPool.Amount.ToDec().Quo(sdk.NewDec(int64(len(validatorWalletList)))).TruncateInt())
-		usedRewardFromMiningPool = sdk.NewCoin(k.RewardDenom(ctx), rewardPerValidator.Amount.Mul(sdk.NewInt(int64(len(validatorWalletList)))))
+		//distributeGoal, idxNodeCnt, resNodeCnt, err := k.CalcMiningRewardInTotalForTestnet(ctx, distributeGoal) //for incentive test net
+		//require.NoError(t, err)
+		//ctx.Logger().Info(distributeGoal.String())
+		//ctx.Logger().Info("---------------------------")
+		//distributeGoalBalance := distributeGoal
+		//rewardDetailMap := make(map[string]types.Reward)
+		//
+		//rewardDetailMap, distributeGoalBalance = k.CalcRewardForResourceNodeForTestnet(ctx, volumeReportMsg.WalletVolumes, distributeGoalBalance, rewardDetailMap, resNodeCnt)
+		//rewardDetailMap, distributeGoalBalance = k.CalcRewardForIndexingNodeForTestnet(ctx, distributeGoalBalance, rewardDetailMap, idxNodeCnt)
+		//
+		////calc mining reward to distribute to validators
+		//rewardFromMiningPool := distributeGoal.BlockChainRewardToValidatorFromMiningPool
+		//usedRewardFromMiningPool := sdk.NewCoin(k.RewardDenom(ctx), sdk.ZeroInt())
+		//validatorWalletList := make([]sdk.AccAddress, 0)
+		//validators := k.StakingKeeper.GetAllValidators(ctx)
+		//for _, validator := range validators {
+		//	if validator.IsBonded() && !validator.IsJailed() {
+		//		validatorWalletList = append(validatorWalletList, sdk.AccAddress(validator.GetOperator()))
+		//	}
+		//}
+		//rewardPerValidator := sdk.NewCoin(k.RewardDenom(ctx), rewardFromMiningPool.Amount.ToDec().Quo(sdk.NewDec(int64(len(validatorWalletList)))).TruncateInt())
+		//usedRewardFromMiningPool = sdk.NewCoin(k.RewardDenom(ctx), rewardPerValidator.Amount.Mul(sdk.NewInt(int64(len(validatorWalletList)))))
 		/********************************************************** Incentive testnet part End *********************************************************************/
 
 		ctx.Logger().Info("resource_wallet1:  address = " + resOwner1.String())
@@ -243,6 +259,7 @@ func TestPotVolumeReportMsgs(t *testing.T) {
 		lastFoundationAccBalance := bankKeeper.GetCoins(ctx, foundationAccAddr)
 		lastFeePool := bankKeeper.GetCoins(ctx, feePoolAccAddr)
 		lastUnissuedPrepay := k.RegisterKeeper.GetTotalUnissuedPrepay(ctx)
+		lastMatureTotalOfResNode1 := k.GetMatureTotalReward(ctx, resOwner2)
 
 		/********************* deliver tx *********************/
 
@@ -257,58 +274,118 @@ func TestPotVolumeReportMsgs(t *testing.T) {
 		ctx = mApp.BaseApp.NewContext(true, header)
 
 		//TODO: recovery when shift to main net
-		//checkResult(t, ctx, k, volumeReportMsg.Epoch, lastFoundationAccBalance, lastUnissuedPrepay, lastFeePool) // Main net
+		checkResult(t, ctx, k, registerKeeper,
+			volumeReportMsg.Epoch,
+			lastFoundationAccBalance,
+			lastUnissuedPrepay,
+			lastFeePool,
+			lastMatureTotalOfResNode1,
+			slashingAmtSetup,
+		) // Main net
 
 		//TODO: remove when shift to main net
-		checkResultForIncentiveTestnet(t, ctx, k, volumeReportMsg.Epoch, lastFoundationAccBalance, lastUnissuedPrepay, lastFeePool, usedRewardFromMiningPool) //Incentive test net
+		//checkResultForIncentiveTestnet(
+		//	t, ctx, k,
+		//	volumeReportMsg.Epoch,
+		//	lastFoundationAccBalance,
+		//	lastUnissuedPrepay,
+		//	lastFeePool,
+		//	usedRewardFromMiningPool,
+		//	slashingAmtSetup,
+		//) //Incentive test net
 
 		i++
 	}
-
 }
 
 //for incentive test net
-func checkResultForIncentiveTestnet(t *testing.T, ctx sdk.Context, k Keeper, currentEpoch sdk.Int,
-	lastFoundationAccBalance sdk.Coins, lastUnissuedPrepay sdk.Coin, lastFeePool sdk.Coins, validatorDirectDeposited sdk.Coin) {
+//func checkResultForIncentiveTestnet(t *testing.T, ctx sdk.Context, k Keeper,
+//	currentEpoch sdk.Int,
+//	lastFoundationAccBalance sdk.Coins,
+//	lastUnissuedPrepay sdk.Coin,
+//	lastFeePool sdk.Coins,
+//	validatorDirectDeposited sdk.Coin,
+//	slashingAmtSetup sdk.Int) {
+//
+//	currentSlashing := k.RegisterKeeper.GetSlashing(ctx, resNodeAddr2)
+//	println("currentSlashing=" + currentSlashing.String())
+//
+//	individualRewardTotal := sdk.Coins{}
+//	newMatureEpoch := currentEpoch.Add(sdk.NewInt(k.MatureEpoch(ctx)))
+//	rewardAddrList := k.GetRewardAddressPool(ctx)
+//	for _, addr := range rewardAddrList {
+//		individualReward, found := k.GetIndividualReward(ctx, addr, newMatureEpoch)
+//		if found {
+//			individualRewardTotal = individualRewardTotal.Add(individualReward.RewardFromTrafficPool...).Add(individualReward.RewardFromMiningPool...)
+//		}
+//
+//		ctx.Logger().Info("individualReward of [" + addr.String() + "] = " + individualReward.String())
+//	}
+//
+//	feePoolAccAddr := k.SupplyKeeper.GetModuleAddress(auth.FeeCollectorName)
+//	foundationAccAddr := k.SupplyKeeper.GetModuleAddress(types.FoundationAccount)
+//	newFoundationAccBalance := k.BankKeeper.GetCoins(ctx, foundationAccAddr)
+//	newUnissuedPrepay := sdk.NewCoins(k.RegisterKeeper.GetTotalUnissuedPrepay(ctx))
+//
+//	slashingChange := slashingAmtSetup.Sub(k.RegisterKeeper.GetSlashing(ctx, resOwner1))
+//	ctx.Logger().Info("resource node 1 slashing change	= " + slashingChange.String())
+//	matureTotal := k.GetMatureTotalReward(ctx, resOwner1)
+//	immatureTotal := k.GetImmatureTotalReward(ctx, resOwner1)
+//	ctx.Logger().Info("resource node 1 matureTotal		= " + matureTotal.String())
+//	ctx.Logger().Info("resource node 1 immatureTotal	= " + immatureTotal.String())
+//
+//	rewardSrcChange := lastFoundationAccBalance.
+//		Sub(newFoundationAccBalance).
+//		Add(lastUnissuedPrepay).
+//		Sub(newUnissuedPrepay)
+//
+//	ctx.Logger().Info("rewardSrcChange					= " + rewardSrcChange.String())
+//
+//	rewardSrcChangeSubSlashing := deductSlashingAmt(ctx, rewardSrcChange, slashingChange)
+//
+//	newFeePool := k.BankKeeper.GetCoins(ctx, feePoolAccAddr)
+//	ctx.Logger().Info("lastFeePool	= " + lastFeePool.String())
+//	ctx.Logger().Info("newFeePool	= " + newFeePool.String())
+//
+//	feePoolValChange := newFeePool.Sub(lastFeePool)
+//	ctx.Logger().Info("reward send to validator fee pool= " + feePoolValChange.String())
+//	rewardDestChange := feePoolValChange.Add(individualRewardTotal...).Add(validatorDirectDeposited)
+//
+//	rewardDestChange = k.RegisterKeeper.DeductSlashing(ctx, resOwner1, rewardDestChange)
+//
+//	ctx.Logger().Info("rewardDestChange	= " + rewardDestChange.String())
+//	require.Equal(t, rewardSrcChangeSubSlashing, rewardDestChange)
+//
+//}
 
-	individualRewardTotal := sdk.Coins{}
-	newMatureEpoch := currentEpoch.Add(sdk.NewInt(k.MatureEpoch(ctx)))
-	rewardAddrList := k.GetRewardAddressPool(ctx)
-	for _, addr := range rewardAddrList {
-		individualReward, found := k.GetIndividualReward(ctx, addr, newMatureEpoch)
-		if found {
-			individualRewardTotal = individualRewardTotal.Add(individualReward.RewardFromTrafficPool...).Add(individualReward.RewardFromMiningPool...)
+// return : coins - slashing
+func deductSlashingAmt(ctx sdk.Context, coins sdk.Coins, slashing sdk.Int) sdk.Coins {
+	ret := sdk.Coins{}
+	for _, coin := range coins {
+		if coin.Amount.GTE(slashing) {
+			coin = coin.Sub(sdk.NewCoin(coin.Denom, slashing))
+			ret = ret.Add(coin)
+			slashing = sdk.ZeroInt()
+		} else {
+			slashing = slashing.Sub(coin.Amount)
+			coin = sdk.NewCoin(coin.Denom, sdk.ZeroInt())
+			ret = ret.Add(coin)
 		}
-
-		ctx.Logger().Info("individualReward of [" + addr.String() + "] = " + individualReward.String())
 	}
-
-	feePoolAccAddr := k.SupplyKeeper.GetModuleAddress(auth.FeeCollectorName)
-	foundationAccAddr := k.SupplyKeeper.GetModuleAddress(types.FoundationAccount)
-	newFoundationAccBalance := k.BankKeeper.GetCoins(ctx, foundationAccAddr)
-	newUnissuedPrepay := sdk.NewCoins(k.RegisterKeeper.GetTotalUnissuedPrepay(ctx))
-
-	rewardSrcChange := lastFoundationAccBalance.
-		Sub(newFoundationAccBalance).
-		Add(lastUnissuedPrepay).
-		Sub(newUnissuedPrepay)
-
-	newFeePool := k.BankKeeper.GetCoins(ctx, feePoolAccAddr)
-
-	feePoolValChange := newFeePool.Sub(lastFeePool)
-	ctx.Logger().Info("reward send to validator fee pool                               = " + feePoolValChange.String())
-
-	rewardDestChange := feePoolValChange.Add(individualRewardTotal...).Add(validatorDirectDeposited)
-
-	ctx.Logger().Info("rewardSrcChange = " + rewardSrcChange.String())
-	ctx.Logger().Info("rewardDestChange = " + rewardDestChange.String())
-	require.Equal(t, rewardSrcChange, rewardDestChange)
-
+	return ret
 }
 
 //for main net
-func checkResult(t *testing.T, ctx sdk.Context, k Keeper, currentEpoch sdk.Int,
-	lastFoundationAccBalance sdk.Coins, lastUnissuedPrepay sdk.Coin, lastFeePool sdk.Coins) {
+func checkResult(t *testing.T, ctx sdk.Context, k Keeper, registerKeeper register.Keeper,
+	currentEpoch sdk.Int,
+	lastFoundationAccBalance sdk.Coins,
+	lastUnissuedPrepay sdk.Coin,
+	lastFeePool sdk.Coins,
+	lastMatureTotalOfResNode1 sdk.Coins,
+	slashingAmtSetup sdk.Int) {
+
+	currentSlashing := registerKeeper.GetSlashing(ctx, resNodeAddr2)
+	println("currentSlashing							=" + currentSlashing.String())
 
 	individualRewardTotal := sdk.Coins{}
 	newMatureEpoch := currentEpoch.Add(sdk.NewInt(k.MatureEpoch(ctx)))
@@ -325,22 +402,58 @@ func checkResult(t *testing.T, ctx sdk.Context, k Keeper, currentEpoch sdk.Int,
 	feePoolAccAddr := k.SupplyKeeper.GetModuleAddress(auth.FeeCollectorName)
 	foundationAccAddr := k.SupplyKeeper.GetModuleAddress(types.FoundationAccount)
 	newFoundationAccBalance := k.BankKeeper.GetCoins(ctx, foundationAccAddr)
-	newUnissuedPrepay := sdk.NewCoins(k.RegisterKeeper.GetTotalUnissuedPrepay(ctx))
+	newUnissuedPrepay := sdk.NewCoins(registerKeeper.GetTotalUnissuedPrepay(ctx))
+
+	slashingChange := slashingAmtSetup.Sub(registerKeeper.GetSlashing(ctx, resOwner1))
+	ctx.Logger().Info("resource node 1 slashing change	= " + slashingChange.String())
+	matureTotal := k.GetMatureTotalReward(ctx, resOwner1)
+	immatureTotal := k.GetImmatureTotalReward(ctx, resOwner1)
+	ctx.Logger().Info("resource node 1 matureTotal		= " + matureTotal.String())
+	ctx.Logger().Info("resource node 1 immatureTotal	= " + immatureTotal.String())
 
 	rewardSrcChange := lastFoundationAccBalance.
 		Sub(newFoundationAccBalance).
 		Add(lastUnissuedPrepay).
 		Sub(newUnissuedPrepay)
+	ctx.Logger().Info("rewardSrcChange					= " + rewardSrcChange.String())
 
+	// get fee pool changes
 	newFeePool := k.BankKeeper.GetCoins(ctx, feePoolAccAddr)
+	ctx.Logger().Info("lastFeePool						= " + lastFeePool.String())
+	ctx.Logger().Info("newFeePool						= " + newFeePool.String())
 
 	feePoolValChange := newFeePool.Sub(lastFeePool)
-	ctx.Logger().Info("reward send to validator fee pool                               = " + feePoolValChange.String())
+	ctx.Logger().Info("reward send to validator fee pool= " + feePoolValChange.String())
 
 	rewardDestChange := feePoolValChange.Add(individualRewardTotal...)
+	ctx.Logger().Info("rewardDestChange					= " + rewardDestChange.String())
 
 	require.Equal(t, rewardSrcChange, rewardDestChange)
 
+	ctx.Logger().Info("************************ slashing test***********************************")
+	ctx.Logger().Info("slashing change					= " + slashingChange.String())
+
+	upcomingMaturedIndividual := sdk.Coins{}
+	individualReward, found := k.GetIndividualReward(ctx, resOwner1, currentEpoch)
+	if found {
+		tmp := individualReward.RewardFromTrafficPool.Add(individualReward.RewardFromMiningPool...)
+		upcomingMaturedIndividual = deductSlashingAmt(ctx, tmp, slashingChange)
+	}
+	ctx.Logger().Info("upcomingMaturedIndividual		= " + upcomingMaturedIndividual.String())
+
+	// get mature total changes
+	newMatureTotalOfResNode1 := k.GetMatureTotalReward(ctx, resOwner1)
+	matureTotalOfResNode1Change, _ := newMatureTotalOfResNode1.SafeSub(lastMatureTotalOfResNode1)
+
+	if upcomingMaturedIndividual == nil {
+		upcomingMaturedIndividual = sdk.Coins{}
+	}
+	if matureTotalOfResNode1Change == nil || matureTotalOfResNode1Change.IsAnyNegative() {
+		matureTotalOfResNode1Change = sdk.Coins{}
+	}
+
+	ctx.Logger().Info("matureTotalOfResNode1Change				= " + matureTotalOfResNode1Change.String())
+	require.Equal(t, matureTotalOfResNode1Change, upcomingMaturedIndividual)
 }
 
 func checkValidator(t *testing.T, mApp *mock.App, stakingKeeper staking.Keeper,
@@ -353,7 +466,7 @@ func checkValidator(t *testing.T, mApp *mock.App, stakingKeeper staking.Keeper,
 	return validator
 }
 
-func getMockApp(t *testing.T) (*mock.App, Keeper, staking.Keeper, bank.Keeper, supply.Keeper) {
+func getMockApp(t *testing.T) (*mock.App, Keeper, staking.Keeper, bank.Keeper, supply.Keeper, register.Keeper) {
 	mApp := mock.NewApp()
 
 	RegisterCodec(mApp.Cdc)
@@ -399,7 +512,7 @@ func getMockApp(t *testing.T) (*mock.App, Keeper, staking.Keeper, bank.Keeper, s
 	err := mApp.CompleteSetup(keyStaking, keySupply, keyRegister, keyPot)
 	require.NoError(t, err)
 
-	return mApp, keeper, stakingKeeper, bankKeeper, supplyKeeper
+	return mApp, keeper, stakingKeeper, bankKeeper, supplyKeeper, registerKeeper
 }
 
 // getInitChainer initializes the chainer of the mock app and sets the genesis

--- a/x/pot/client/rest/query.go
+++ b/x/pot/client/rest/query.go
@@ -17,7 +17,7 @@ func registerQueryRoutes(cliCtx context.CLIContext, r *mux.Router) {
 	r.HandleFunc("/pot/report/epoch/{epoch}", getVolumeReportHandlerFn(cliCtx, keeper.QueryVolumeReport)).Methods("GET")
 	r.HandleFunc("/pot/rewards/epoch/{epoch}", getPotRewardsByEpochHandlerFn(cliCtx, keeper.QueryPotRewardsByReportEpoch)).Methods("GET")
 	r.HandleFunc("/pot/rewards/wallet/{walletAddress}", getPotRewardsByWalletAddrHandlerFn(cliCtx, keeper.QueryPotRewardsByWalletAddr)).Methods("GET")
-	r.HandleFunc("/pot/slashing/{p2pAddress}", getPotSlashingByP2pAddressHandlerFn(cliCtx, keeper.QueryPotSlashingByP2pAddr)).Methods("GET")
+	r.HandleFunc("/pot/slashing/{walletAddress}", getPotSlashingByWalletAddressHandlerFn(cliCtx, keeper.QueryPotSlashingByWalletAddr)).Methods("GET")
 }
 
 func getPotRewardsByEpochHandlerFn(cliCtx context.CLIContext, queryPath string) http.HandlerFunc {
@@ -150,21 +150,21 @@ func getPotRewardsByWalletAddrHandlerFn(cliCtx context.CLIContext, queryPath str
 	}
 }
 
-func getPotSlashingByP2pAddressHandlerFn(cliCtx context.CLIContext, queryPath string) http.HandlerFunc {
+func getPotSlashingByWalletAddressHandlerFn(cliCtx context.CLIContext, queryPath string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		cliCtx, ok := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
 		if !ok {
 			return
 		}
 
-		v := mux.Vars(r)["p2pAddress"]
+		v := mux.Vars(r)["walletAddress"]
 		if len(v) == 0 {
 			return
 		}
-		p2pAddr, err := sdk.AccAddressFromBech32(v)
+		walletAddr, err := sdk.AccAddressFromBech32(v)
 
 		route := fmt.Sprintf("custom/%s/%s", types.QuerierRoute, queryPath)
-		res, height, err := cliCtx.QueryWithData(route, []byte(p2pAddr.String()))
+		res, height, err := cliCtx.QueryWithData(route, []byte(walletAddr.String()))
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return

--- a/x/pot/genesis.go
+++ b/x/pot/genesis.go
@@ -2,7 +2,6 @@ package pot
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	stratos "github.com/stratosnet/stratos-chain/types"
 	"github.com/stratosnet/stratos-chain/x/pot/types"
 )
 
@@ -25,9 +24,6 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, data types.GenesisState) {
 		keeper.SetIndividualReward(ctx, individual.WalletAddress, sdk.NewInt(data.LastReportedEpoch+1), individual)
 	}
 
-	for _, slashing := range data.SlashingInfo {
-		keeper.SetSlashing(ctx, slashing.P2pAddress, slashing.Value)
-	}
 }
 
 // ExportGenesis writes the current store values
@@ -63,13 +59,6 @@ func ExportGenesis(ctx sdk.Context, keeper Keeper) (data types.GenesisState) {
 		return false
 	})
 
-	var slashingInfo []types.Slashing
-	keeper.IteratorSlashingInfo(ctx, func(p2pAddress stratos.SdsAddress, val sdk.Int) (stop bool) {
-		slashing := types.NewSlashing(p2pAddress, val)
-		slashingInfo = append(slashingInfo, slashing)
-		return false
-	})
-
 	return types.NewGenesisState(params, totalMinedToken, lastReportedEpoch.Int64(),
-		immatureTotalInfo, matureTotalInfo, individualRewardInfo, slashingInfo)
+		immatureTotalInfo, matureTotalInfo, individualRewardInfo)
 }

--- a/x/pot/keeper/distribute.go
+++ b/x/pot/keeper/distribute.go
@@ -267,7 +267,12 @@ func (k Keeper) addNewRewardAndReCalcTotal(ctx sdk.Context, account sdk.AccAddre
 		immatureToMature = immatureToMature.Add(rewardTotal...)
 	}
 
-	matureTotal := oldMatureTotal.Add(immatureToMature...)
+	//deduct slashing amount from mature total pool
+	finalMatureTotal := k.RegisterKeeper.DeductSlashing(ctx, account, oldMatureTotal)
+	//deduct slashing amount from upcoming mature reward, don't need to deduct slashing from immatureTotal & individual
+	finalNewMature := k.RegisterKeeper.DeductSlashing(ctx, account, immatureToMature)
+
+	matureTotal := finalMatureTotal.Add(finalNewMature...)
 	immatureTotal := oldImmatureTotal.Sub(immatureToMature).Add(newRewardTotal...)
 
 	rewardAddressPool := k.GetRewardAddressPool(ctx)

--- a/x/pot/keeper/distribute.go
+++ b/x/pot/keeper/distribute.go
@@ -155,7 +155,7 @@ func (k Keeper) CalcTrafficRewardInTotal(
 	ctx sdk.Context, trafficList []types.SingleWalletVolume, distributeGoal types.DistributeGoal,
 ) (sdk.Dec, types.DistributeGoal, error) {
 
-	totalConsumedOzone, totalTrafficReward := k.getTrafficReward(ctx, trafficList)
+	totalConsumedOzone, totalTrafficReward := k.GetTrafficReward(ctx, trafficList)
 	totalMinedTokens := k.GetTotalMinedTokens(ctx)
 	miningParam, err := k.GetMiningRewardParamByMinedToken(ctx, totalMinedTokens)
 	if err != nil && err != types.ErrOutOfIssuance {
@@ -187,7 +187,7 @@ func (k Keeper) CalcTrafficRewardInTotal(
 // The remaining total Ozone limit [lt] is the upper bound of total Ozone that users can purchase from Stratos blockchain.
 // the total generated traffic rewards as [R]
 // R = (S + Pt) * Y / (Lt + Y)
-func (k Keeper) getTrafficReward(ctx sdk.Context, trafficList []types.SingleWalletVolume) (totalConsumedOzone, result sdk.Dec) {
+func (k Keeper) GetTrafficReward(ctx sdk.Context, trafficList []types.SingleWalletVolume) (totalConsumedOzone, result sdk.Dec) {
 	S := k.RegisterKeeper.GetInitialGenesisStakeTotal(ctx).ToDec()
 	if S.Equal(sdk.ZeroDec()) {
 		ctx.Logger().Info("initial genesis deposit by all resource nodes and meta nodes is 0")

--- a/x/pot/keeper/distribute_test.go
+++ b/x/pot/keeper/distribute_test.go
@@ -234,11 +234,6 @@ func testFullDistributeProcessAtEpoch2017(t *testing.T, ctx sdk.Context, k Keepe
 	_, err := k.DistributePotReward(ctx, trafficList, epoch2017)
 	require.NoError(t, err)
 	fmt.Println("Distribution result at Epoch2017: ")
-	rewardAddrList := k.GetRewardAddressPool(ctx)
-	fmt.Println("address pool: ")
-	for i := 0; i < len(rewardAddrList); i++ {
-		fmt.Println(rewardAddrList[i].String() + ", ")
-	}
 	fmt.Println("----------------------------------------------------------------------------------")
 
 	idvRwdResNode1Ep1, _ := k.GetIndividualReward(ctx, resOwner1, epoch4033)
@@ -323,11 +318,6 @@ func testFullDistributeProcessAtEpoch1(t *testing.T, ctx sdk.Context, k Keeper, 
 	require.NoError(t, err)
 
 	fmt.Println("Distribution result at Epoch1: ")
-	rewardAddrList := k.GetRewardAddressPool(ctx)
-	fmt.Println("address pool: ")
-	for i := 0; i < len(rewardAddrList); i++ {
-		fmt.Println(rewardAddrList[i].String() + ", ")
-	}
 	fmt.Println("----------------------------------------------------------------------------------")
 
 	idvRwdResNode1Ep1, _ := k.GetIndividualReward(ctx, resOwner1, epoch2017)

--- a/x/pot/keeper/distribute_test.go
+++ b/x/pot/keeper/distribute_test.go
@@ -471,7 +471,7 @@ func testMetaNodeRewardFromTrafficPool(t *testing.T, ctx sdk.Context, k Keeper, 
 	distributeGoal := types.InitDistributeGoal()
 	rewardDetailMap := make(map[string]types.Reward)
 
-	_, totalReward := k.getTrafficReward(ctx, trafficList)
+	_, totalReward := k.GetTrafficReward(ctx, trafficList)
 
 	//1, calc traffic reward in total
 	_, distributeGoal, err := k.CalcTrafficRewardInTotal(ctx, trafficList, distributeGoal)
@@ -534,7 +534,7 @@ func testTrafficRewardFromTrafficPool(t *testing.T, ctx sdk.Context, k Keeper, b
 	distributeGoal := types.InitDistributeGoal()
 	rewardDetailMap := make(map[string]types.Reward)
 
-	_, totalReward := k.getTrafficReward(ctx, trafficList)
+	_, totalReward := k.GetTrafficReward(ctx, trafficList)
 
 	//1, calc traffic reward in total
 	_, distributeGoal, err := k.CalcTrafficRewardInTotal(ctx, trafficList, distributeGoal)

--- a/x/pot/keeper/keeper.go
+++ b/x/pot/keeper/keeper.go
@@ -61,9 +61,9 @@ func (k Keeper) VolumeReport(ctx sdk.Context, walletVolumes []types.SingleWallet
 	k.SetVolumeReport(ctx, epoch, reportRecord)
 	//distribute POT reward
 	//TODO: recovery when shift to main net
-	//totalConsumedOzone, err = k.DistributePotReward(ctx, walletVolumes, epoch) // Main net
+	totalConsumedOzone, err = k.DistributePotReward(ctx, walletVolumes, epoch) // Main net
 	//TODO: remove when shift to main net
-	totalConsumedOzone, err = k.DistributePotRewardForTestnet(ctx, walletVolumes, epoch) // Incentive test net
+	//totalConsumedOzone, err = k.DistributePotRewardForTestnet(ctx, walletVolumes, epoch) // Incentive test net
 
 	return totalConsumedOzone, err
 }

--- a/x/pot/keeper/querier.go
+++ b/x/pot/keeper/querier.go
@@ -87,13 +87,10 @@ func (k Keeper) getPotRewardsByReportEpoch(ctx sdk.Context, params types.QueryPo
 			res = append(res, reward)
 		}
 	} else {
-		rewardAddressPool := k.GetRewardAddressPool(ctx)
-		for _, walletAddress := range rewardAddressPool {
-			reward, found := k.GetIndividualReward(ctx, walletAddress, matureEpoch)
-			if found {
-				res = append(res, reward)
-			}
-		}
+		k.IteratorIndividualReward(ctx, matureEpoch, func(walletAddress sdk.AccAddress, individualReward types.Reward) (stop bool) {
+			res = append(res, individualReward)
+			return false
+		})
 	}
 
 	start, end := client.Paginate(len(res), params.Page, params.Limit, QueryDefaultLimit)

--- a/x/pot/keeper/querier.go
+++ b/x/pot/keeper/querier.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	stratos "github.com/stratosnet/stratos-chain/types"
 	"github.com/stratosnet/stratos-chain/x/pot/types"
 	abci "github.com/tendermint/tendermint/abci/types"
 )
@@ -17,7 +16,7 @@ const (
 	QueryVolumeReport            = "query_volume_report"
 	QueryPotRewardsByReportEpoch = "query_pot_rewards_by_report_epoch"
 	QueryPotRewardsByWalletAddr  = "query_pot_rewards_by_wallet_address"
-	QueryPotSlashingByP2pAddr    = "query_pot_slashing_by_p2p_address"
+	QueryPotSlashingByWalletAddr = "query_pot_slashing_by_wallet_address"
 	QueryDefaultLimit            = 100
 )
 
@@ -31,8 +30,8 @@ func NewQuerier(k Keeper) sdk.Querier {
 			return queryPotRewardsByReportEpoch(ctx, req, k)
 		case QueryPotRewardsByWalletAddr:
 			return queryPotRewardsByWalletAddress(ctx, req, k)
-		case QueryPotSlashingByP2pAddr:
-			return queryPotSlashingByP2pAddress(ctx, req, k)
+		case QueryPotSlashingByWalletAddr:
+			return queryPotSlashingByWalletAddress(ctx, req, k)
 		default:
 			return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, "unknown pot query endpoint")
 		}
@@ -123,11 +122,11 @@ func queryPotRewardsByWalletAddress(ctx sdk.Context, req abci.RequestQuery, k Ke
 	return bz, nil
 }
 
-func queryPotSlashingByP2pAddress(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte, error) {
-	addr, err := stratos.SdsAddressFromBech32(string(req.Data))
+func queryPotSlashingByWalletAddress(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte, error) {
+	addr, err := sdk.AccAddressFromBech32(string(req.Data))
 	if err != nil {
 		return []byte(sdk.ZeroInt().String()), types.ErrUnknownAccountAddress
 	}
 
-	return []byte(k.GetSlashing(ctx, addr).String()), nil
+	return []byte(k.RegisterKeeper.GetSlashing(ctx, addr).String()), nil
 }

--- a/x/pot/keeper/slashing.go
+++ b/x/pot/keeper/slashing.go
@@ -26,7 +26,7 @@ func (k Keeper) SlashingResourceNode(ctx sdk.Context, p2pAddr stratos.SdsAddress
 	node.Suspend = suspend
 
 	//slashing amt is equivalent to reward traffic calculation
-	_, slash := k.getTrafficReward(ctx, []types.SingleWalletVolume{{
+	_, slash := k.GetTrafficReward(ctx, []types.SingleWalletVolume{{
 		WalletAddress: node.GetOwnerAddr(),
 		Volume:        ozAmt,
 	}})

--- a/x/pot/keeper/store.go
+++ b/x/pot/keeper/store.go
@@ -37,22 +37,6 @@ func (k Keeper) GetMinedTokens(ctx sdk.Context, epoch sdk.Int) (minedToken sdk.C
 	return
 }
 
-func (k Keeper) setRewardAddressPool(ctx sdk.Context, walletAddressList []sdk.AccAddress) {
-	store := ctx.KVStore(k.storeKey)
-	b := k.cdc.MustMarshalBinaryLengthPrefixed(walletAddressList)
-	store.Set(types.RewardAddressPoolKey, b)
-}
-
-func (k Keeper) GetRewardAddressPool(ctx sdk.Context) (walletAddressList []sdk.AccAddress) {
-	store := ctx.KVStore(k.storeKey)
-	b := store.Get(types.RewardAddressPoolKey)
-	if b == nil {
-		return nil
-	}
-	k.cdc.MustUnmarshalBinaryLengthPrefixed(b, &walletAddressList)
-	return
-}
-
 func (k Keeper) SetLastReportedEpoch(ctx sdk.Context, epoch sdk.Int) {
 	store := ctx.KVStore(k.storeKey)
 	b := k.cdc.MustMarshalBinaryLengthPrefixed(epoch)

--- a/x/pot/keeper/store.go
+++ b/x/pot/keeper/store.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	stratos "github.com/stratosnet/stratos-chain/types"
 	"github.com/stratosnet/stratos-chain/x/pot/types"
 )
 
@@ -133,21 +132,4 @@ func (k Keeper) SetVolumeReport(ctx sdk.Context, epoch sdk.Int, reportRecord typ
 	storeKey := types.VolumeReportStoreKey(epoch)
 	bz := k.cdc.MustMarshalBinaryLengthPrefixed(reportRecord)
 	store.Set(storeKey, bz)
-}
-
-func (k Keeper) SetSlashing(ctx sdk.Context, p2pAddress stratos.SdsAddress, slashing sdk.Int) {
-	store := ctx.KVStore(k.storeKey)
-	storeKey := types.GetSlashingKey(p2pAddress)
-	bz := k.cdc.MustMarshalBinaryLengthPrefixed(slashing)
-	store.Set(storeKey, bz)
-}
-
-func (k Keeper) GetSlashing(ctx sdk.Context, p2pAddress stratos.SdsAddress) (res sdk.Int) {
-	store := ctx.KVStore(k.storeKey)
-	bz := store.Get(types.GetSlashingKey(p2pAddress))
-	if bz == nil {
-		return sdk.ZeroInt()
-	}
-	k.cdc.MustUnmarshalBinaryLengthPrefixed(bz, &res)
-	return
 }

--- a/x/pot/pot_test.go
+++ b/x/pot/pot_test.go
@@ -1,6 +1,7 @@
 package pot
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -33,12 +34,14 @@ var (
 	ConsNodePubKeyPrefix   = StratosBech32Prefix + "valconspub"
 	SdsNodeP2PKeyPrefix    = StratosBech32Prefix + "sdsp2p"
 
-	resourceNodeVolume1 = sdk.NewInt(500000000000)
-	resourceNodeVolume2 = sdk.NewInt(300000000000)
-	resourceNodeVolume3 = sdk.NewInt(200000000000)
+	resNodeSlashingUOZAmt1 = sdk.NewInt(1000000000000000000)
+
+	resourceNodeVolume1 = sdk.NewInt(500000)
+	resourceNodeVolume2 = sdk.NewInt(300000)
+	resourceNodeVolume3 = sdk.NewInt(200000)
 
 	depositForSendingTx, _    = sdk.NewIntFromString("100000000000000000000000000000")
-	totalUnissuedPrepayVal, _ = sdk.NewIntFromString("100000000000000000000000000000")
+	totalUnissuedPrepayVal, _ = sdk.NewIntFromString("1000000000000")
 	totalUnissuedPrepay       = sdk.NewCoin("ustos", totalUnissuedPrepayVal)
 	initialUOzonePrice        = sdk.NewDecWithPrec(10000000, 9) // 0.001 ustos -> 1 uoz
 
@@ -117,9 +120,9 @@ var (
 
 func TestMain(m *testing.M) {
 	config := stratos.GetConfig()
-
 	config.Seal()
-
+	exitVal := m.Run()
+	os.Exit(exitVal)
 }
 
 func setupAccounts(mApp *mock.App) []authexported.Account {
@@ -272,7 +275,6 @@ func SignCheckDeliver(
 
 	// Simulate a sending a transaction and committing a block
 	app.BeginBlock(abci.RequestBeginBlock{Header: header})
-
 	gInfo, res, err := app.Deliver(tx)
 
 	if expPass {
@@ -294,7 +296,7 @@ func GenTx(msgs []sdk.Msg, accnums []uint64, seq []uint64, priv ...crypto.PrivKe
 	// Make the transaction free
 	fee := auth.StdFee{
 		Amount: sdk.NewCoins(sdk.NewInt64Coin("foocoin", 0)),
-		Gas:    600000,
+		Gas:    5000000,
 	}
 
 	sigs := make([]auth.StdSignature, len(priv))

--- a/x/pot/types/genesis.go
+++ b/x/pot/types/genesis.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	stratos "github.com/stratosnet/stratos-chain/types"
 )
 
 type GenesisState struct {
@@ -12,12 +11,11 @@ type GenesisState struct {
 	ImmatureTotalInfo    []ImmatureTotal `json:"immature_total_info" yaml:"immature_total_info"`
 	MatureTotalInfo      []MatureTotal   `json:"mature_total_info" yaml:"mature_total_info"`
 	IndividualRewardInfo []Reward        `json:"individual_reward_info" yaml:"individual_reward_info"`
-	SlashingInfo         []Slashing      `json:"slashing_info" yaml:"slashing_info"`
 }
 
 // NewGenesisState creates a new GenesisState object
 func NewGenesisState(params Params, totalMinedToken sdk.Coin, lastReportedEpoch int64,
-	immatureTotalInfo []ImmatureTotal, matureTotalInfo []MatureTotal, individualRewardInfo []Reward, slashingInfo []Slashing,
+	immatureTotalInfo []ImmatureTotal, matureTotalInfo []MatureTotal, individualRewardInfo []Reward,
 ) GenesisState {
 
 	return GenesisState{
@@ -27,7 +25,6 @@ func NewGenesisState(params Params, totalMinedToken sdk.Coin, lastReportedEpoch 
 		ImmatureTotalInfo:    immatureTotalInfo,
 		MatureTotalInfo:      matureTotalInfo,
 		IndividualRewardInfo: individualRewardInfo,
-		SlashingInfo:         slashingInfo,
 	}
 }
 
@@ -40,7 +37,6 @@ func DefaultGenesisState() GenesisState {
 		ImmatureTotalInfo:    make([]ImmatureTotal, 0),
 		MatureTotalInfo:      make([]MatureTotal, 0),
 		IndividualRewardInfo: make([]Reward, 0),
-		SlashingInfo:         make([]Slashing, 0),
 	}
 }
 
@@ -70,17 +66,5 @@ func NewMatureTotal(walletAddress sdk.AccAddress, value sdk.Coins) MatureTotal {
 	return MatureTotal{
 		WalletAddress: walletAddress,
 		Value:         value,
-	}
-}
-
-type Slashing struct {
-	P2pAddress stratos.SdsAddress
-	Value      sdk.Int
-}
-
-func NewSlashing(p2pAddress stratos.SdsAddress, value sdk.Int) Slashing {
-	return Slashing{
-		P2pAddress: p2pAddress,
-		Value:      value,
 	}
 }

--- a/x/pot/types/key.go
+++ b/x/pot/types/key.go
@@ -22,11 +22,10 @@ var (
 	TotalMinedTokensKey  = []byte{0x03}
 	MinedTokensKeyPrefix = []byte{0x04} // key: prefix_epoch
 
-	RewardAddressPoolKey         = []byte{0x11}
 	LastReportedEpochKey         = []byte{0x12}
-	IndividualRewardKeyPrefix    = []byte{0x13} // key: prefix{address}_individual_{epoch}, the amount that is matured at {epoch}
-	MatureTotalRewardKeyPrefix   = []byte{0x14} // key: prefix{address}_mature_total
-	ImmatureTotalRewardKeyPrefix = []byte{0x15} // key: prefix{address}_immature_total
+	IndividualRewardKeyPrefix    = []byte{0x13} // key: prefix{address}_{epoch}, the amount that is matured at {epoch}
+	MatureTotalRewardKeyPrefix   = []byte{0x14} // key: prefix{address}
+	ImmatureTotalRewardKeyPrefix = []byte{0x15} // key: prefix{address}
 
 	VolumeReportStoreKeyPrefix = []byte{0x41} // VolumeReportStoreKeyPrefix prefix for volumeReport store
 )
@@ -40,29 +39,33 @@ func VolumeReportStoreKey(epoch sdk.Int) []byte {
 	return append(VolumeReportStoreKeyPrefix, epoch.String()...)
 }
 
-// GetIndividualRewardKey prefix{address}_individual_{epoch}, the amount that is matured at {epoch}
+// GetIndividualRewardKey prefix{epoch}_{account}, the amount that is matured at {epoch}
 func GetIndividualRewardKey(acc sdk.AccAddress, epoch sdk.Int) []byte {
-	bKeyStr := []byte("_individual_")
+	bKeyStr := []byte("_")
 	bEpoch := []byte(epoch.String())
 
-	key := append(IndividualRewardKeyPrefix, acc...)
+	key := append(IndividualRewardKeyPrefix, bEpoch...)
 	key = append(key, bKeyStr...)
-	key = append(key, bEpoch...)
+	key = append(key, acc...)
 	return key
 }
 
-// GetMatureTotalRewardKey prefix{address}_mature_total
+func GetIndividualRewardIteratorKey(epoch sdk.Int) []byte {
+	bKeyStr := []byte("_")
+	bEpoch := []byte(epoch.String())
+	key := append(IndividualRewardKeyPrefix, bEpoch...)
+	key = append(key, bKeyStr...)
+	return key
+}
+
+// GetMatureTotalRewardKey prefix{address}
 func GetMatureTotalRewardKey(acc sdk.AccAddress) []byte {
-	bKeyStr := []byte("_mature_total")
 	key := append(MatureTotalRewardKeyPrefix, acc.Bytes()...)
-	key = append(key, bKeyStr...)
 	return key
 }
 
-// GetImmatureTotalRewardKey prefix{address}_immature_total
+// GetImmatureTotalRewardKey prefix{address}
 func GetImmatureTotalRewardKey(acc sdk.AccAddress) []byte {
-	bKeyStr := []byte("_immature_total")
 	key := append(ImmatureTotalRewardKeyPrefix, acc.Bytes()...)
-	key = append(key, bKeyStr...)
 	return key
 }

--- a/x/pot/types/key.go
+++ b/x/pot/types/key.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	stratos "github.com/stratosnet/stratos-chain/types"
 )
 
 const (
@@ -28,9 +27,8 @@ var (
 	IndividualRewardKeyPrefix    = []byte{0x13} // key: prefix{address}_individual_{epoch}, the amount that is matured at {epoch}
 	MatureTotalRewardKeyPrefix   = []byte{0x14} // key: prefix{address}_mature_total
 	ImmatureTotalRewardKeyPrefix = []byte{0x15} // key: prefix{address}_immature_total
-	SlashingPrefix               = []byte{0x16} // key: prefix{address}_{epoch}
-	// VolumeReportStoreKeyPrefix prefix for volumeReport store
-	VolumeReportStoreKeyPrefix = []byte{0x41}
+
+	VolumeReportStoreKeyPrefix = []byte{0x41} // VolumeReportStoreKeyPrefix prefix for volumeReport store
 )
 
 func GetMinedTokensKey(epoch sdk.Int) []byte {
@@ -66,10 +64,5 @@ func GetImmatureTotalRewardKey(acc sdk.AccAddress) []byte {
 	bKeyStr := []byte("_immature_total")
 	key := append(ImmatureTotalRewardKeyPrefix, acc.Bytes()...)
 	key = append(key, bKeyStr...)
-	return key
-}
-
-func GetSlashingKey(p2pAddress stratos.SdsAddress) []byte {
-	key := append(SlashingPrefix, p2pAddress...)
 	return key
 }

--- a/x/pot/types/msg.go
+++ b/x/pot/types/msg.go
@@ -216,7 +216,7 @@ type MsgSlashingResourceNode struct {
 	ReporterOwner  []sdk.AccAddress     `json:"reporter_owner" yaml:"reporter_owner"`   // reporter wallet address
 	NetworkAddress stratos.SdsAddress   `json:"network_address" yaml:"network_address"` // p2p address of the pp node
 	WalletAddress  sdk.AccAddress       `json:"wallet_address" yaml:"wallet_address"`   // wallet address of the pp node
-	Slashing       sdk.Int              `json:"slashing" yaml:"slashing"`
+	Slashing       sdk.Int              `json:"slashing" yaml:"slashing"`               // uoz amount
 	Suspend        bool                 `json:"suspend" yaml:"suspend"`
 }
 

--- a/x/register/alias.go
+++ b/x/register/alias.go
@@ -55,6 +55,7 @@ type (
 	IndexingNode          = types.IndexingNode
 	Description           = types.Description
 	GenesisIndexingNode   = types.GenesisIndexingNode
+	Slashing              = types.Slashing
 	MsgCreateResourceNode = types.MsgCreateResourceNode
 	MsgCreateIndexingNode = types.MsgCreateIndexingNode
 	VoteOpinion           = types.VoteOpinion

--- a/x/register/app_test.go
+++ b/x/register/app_test.go
@@ -1,6 +1,7 @@
 package register
 
 import (
+	"os"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -20,9 +21,9 @@ import (
 
 func TestMain(m *testing.M) {
 	config := stratos.GetConfig()
-
 	config.Seal()
-
+	exitVal := m.Run()
+	os.Exit(exitVal)
 }
 
 func Test(t *testing.T) {

--- a/x/register/app_test.go
+++ b/x/register/app_test.go
@@ -202,7 +202,14 @@ func getInitChainer(mapp *mock.App, keeper Keeper, accountKeeper auth.AccountKee
 		resourceNodes := setupAllResourceNodes()
 		indexingNodes := setupAllIndexingNodes()
 
-		registerGenesis := NewGenesisState(DefaultParams(), resourceNodes, indexingNodes, initialUOzonePrice, sdk.ZeroInt())
+		registerGenesis := NewGenesisState(
+			DefaultParams(),
+			resourceNodes,
+			indexingNodes,
+			initialUOzonePrice,
+			sdk.ZeroInt(),
+			make([]Slashing, 0),
+		)
 
 		InitGenesis(ctx, keeper, registerGenesis)
 

--- a/x/register/genesis.go
+++ b/x/register/genesis.go
@@ -50,6 +50,10 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, data types.GenesisState) {
 		Denom:  data.Params.BondDenom,
 		Amount: totalUnissuedPrepay,
 	})
+
+	for _, slashing := range data.SlashingInfo {
+		keeper.SetSlashing(ctx, slashing.WalletAddress, slashing.Value)
+	}
 }
 
 // ExportGenesis writes the current store values
@@ -63,11 +67,19 @@ func ExportGenesis(ctx sdk.Context, keeper Keeper) (data types.GenesisState) {
 	totalUnissuedPrepay := keeper.GetTotalUnissuedPrepay(ctx).Amount
 	initialUOzonePrice := keeper.CurrUozPrice(ctx)
 
+	var slashingInfo []types.Slashing
+	keeper.IteratorSlashingInfo(ctx, func(walletAddress sdk.AccAddress, val sdk.Int) (stop bool) {
+		slashing := types.NewSlashing(walletAddress, val)
+		slashingInfo = append(slashingInfo, slashing)
+		return false
+	})
+
 	return types.GenesisState{
 		Params:              params,
 		ResourceNodes:       resourceNodes,
 		IndexingNodes:       indexingNodes,
 		InitialUozPrice:     initialUOzonePrice,
 		TotalUnissuedPrepay: totalUnissuedPrepay,
+		SlashingInfo:        slashingInfo,
 	}
 }

--- a/x/register/genesis.go
+++ b/x/register/genesis.go
@@ -69,8 +69,10 @@ func ExportGenesis(ctx sdk.Context, keeper Keeper) (data types.GenesisState) {
 
 	var slashingInfo []types.Slashing
 	keeper.IteratorSlashingInfo(ctx, func(walletAddress sdk.AccAddress, val sdk.Int) (stop bool) {
-		slashing := types.NewSlashing(walletAddress, val)
-		slashingInfo = append(slashingInfo, slashing)
+		if val.GT(sdk.ZeroInt()) {
+			slashing := types.NewSlashing(walletAddress, val)
+			slashingInfo = append(slashingInfo, slashing)
+		}
 		return false
 	})
 

--- a/x/register/keeper/indexing_node.go
+++ b/x/register/keeper/indexing_node.go
@@ -191,6 +191,8 @@ func (k Keeper) SubtractIndexingNodeStake(ctx sdk.Context, indexingNode types.In
 	notBondedTokenInPool = notBondedTokenInPool.Sub(tokenToSub)
 	k.SetIndexingNodeNotBondedToken(ctx, notBondedTokenInPool)
 
+	// deduct slashing amount first
+	coins = k.DeductSlashing(ctx, indexingNode.OwnerAddress, coins)
 	// add tokens to owner acc
 	_, err := k.bankKeeper.AddCoins(ctx, indexingNode.OwnerAddress, coins)
 	if err != nil {

--- a/x/register/keeper/resource_node.go
+++ b/x/register/keeper/resource_node.go
@@ -178,6 +178,8 @@ func (k Keeper) SubtractResourceNodeStake(ctx sdk.Context, resourceNode types.Re
 	notBondedTokenInPool = notBondedTokenInPool.Sub(tokenToSub)
 	k.SetResourceNodeNotBondedToken(ctx, notBondedTokenInPool)
 
+	// deduct slashing amount first
+	coins = k.DeductSlashing(ctx, resourceNode.OwnerAddress, coins)
 	// add tokens to owner acc
 	_, err := k.bankKeeper.AddCoins(ctx, resourceNode.OwnerAddress, coins)
 	if err != nil {

--- a/x/register/keeper/slashing.go
+++ b/x/register/keeper/slashing.go
@@ -13,18 +13,20 @@ func (k Keeper) DeductSlashing(ctx sdk.Context, walletAddress sdk.AccAddress, co
 		return coins
 	}
 
+	ret := sdk.Coins{}
 	for _, coin := range coins {
 		if coin.Amount.GTE(slashing) {
 			coin = coin.Sub(sdk.NewCoin(coin.Denom, slashing))
+			ret = ret.Add(coin)
 			slashing = sdk.ZeroInt()
-			break
 		} else {
 			slashing = slashing.Sub(coin.Amount)
 			coin = sdk.NewCoin(coin.Denom, sdk.ZeroInt())
+			ret = ret.Add(coin)
 		}
 	}
 	k.SetSlashing(ctx, walletAddress, slashing)
-	return coins
+	return ret
 }
 
 func (k Keeper) IteratorSlashingInfo(ctx sdk.Context, handler func(walletAddress sdk.AccAddress, slashing sdk.Int) (stop bool)) {

--- a/x/register/keeper/slashing.go
+++ b/x/register/keeper/slashing.go
@@ -1,0 +1,59 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/stratosnet/stratos-chain/x/register/types"
+)
+
+// deduct slashing amount from coins, return the coins that after deduction
+func (k Keeper) DeductSlashing(ctx sdk.Context, walletAddress sdk.AccAddress, coins sdk.Coins) sdk.Coins {
+	slashing := k.GetSlashing(ctx, walletAddress)
+	if slashing.LTE(sdk.ZeroInt()) || coins.Empty() || coins.IsZero() {
+		return coins
+	}
+
+	for _, coin := range coins {
+		if coin.Amount.GTE(slashing) {
+			coin = coin.Sub(sdk.NewCoin(coin.Denom, slashing))
+			slashing = sdk.ZeroInt()
+			break
+		} else {
+			coin = sdk.NewCoin(coin.Denom, sdk.ZeroInt())
+			slashing = slashing.Sub(coin.Amount)
+		}
+	}
+	k.SetSlashing(ctx, walletAddress, slashing)
+	return coins
+}
+
+func (k Keeper) IteratorSlashingInfo(ctx sdk.Context, handler func(walletAddress sdk.AccAddress, slashing sdk.Int) (stop bool)) {
+	store := ctx.KVStore(k.storeKey)
+	iter := sdk.KVStorePrefixIterator(store, types.SlashingPrefix)
+	defer iter.Close()
+	for ; iter.Valid(); iter.Next() {
+		walletAddress := sdk.AccAddress(iter.Key()[len(types.SlashingPrefix):])
+		var slashing sdk.Int
+		k.cdc.MustUnmarshalBinaryLengthPrefixed(iter.Value(), &slashing)
+		if handler(walletAddress, slashing) {
+			break
+		}
+	}
+}
+
+func (k Keeper) SetSlashing(ctx sdk.Context, walletAddress sdk.AccAddress, slashing sdk.Int) {
+	store := ctx.KVStore(k.storeKey)
+	storeKey := types.GetSlashingKey(walletAddress)
+	bz := k.cdc.MustMarshalBinaryLengthPrefixed(slashing)
+	store.Set(storeKey, bz)
+}
+
+func (k Keeper) GetSlashing(ctx sdk.Context, walletAddress sdk.AccAddress) (res sdk.Int) {
+	store := ctx.KVStore(k.storeKey)
+	bz := store.Get(types.GetSlashingKey(walletAddress))
+	if bz == nil {
+		return sdk.ZeroInt()
+	}
+	k.cdc.MustUnmarshalBinaryLengthPrefixed(bz, &res)
+	return
+}

--- a/x/register/keeper/slashing.go
+++ b/x/register/keeper/slashing.go
@@ -19,8 +19,8 @@ func (k Keeper) DeductSlashing(ctx sdk.Context, walletAddress sdk.AccAddress, co
 			slashing = sdk.ZeroInt()
 			break
 		} else {
-			coin = sdk.NewCoin(coin.Denom, sdk.ZeroInt())
 			slashing = slashing.Sub(coin.Amount)
+			coin = sdk.NewCoin(coin.Denom, sdk.ZeroInt())
 		}
 	}
 	k.SetSlashing(ctx, walletAddress, slashing)

--- a/x/register/types/errors.go
+++ b/x/register/types/errors.go
@@ -48,4 +48,5 @@ var (
 	ErrInvalidStakeChange                 = sdkerrors.Register(ModuleName, 41, "invalid change for stake")
 	ErrTotalUnissuedPrepay                = sdkerrors.Register(ModuleName, 42, "total unissued prepay must be non-negative")
 	ErrInvalidNodeType                    = sdkerrors.Register(ModuleName, 43, "invalid node type")
+	ErrUnknownAccountAddress              = sdkerrors.Register(ModuleName, 44, "account address does not exist")
 )

--- a/x/register/types/genesis.go
+++ b/x/register/types/genesis.go
@@ -15,13 +15,16 @@ type GenesisState struct {
 	IndexingNodes       IndexingNodes `json:"indexing_nodes" yaml:"indexing_nodes"`
 	InitialUozPrice     sdk.Dec       `json:"initial_uoz_price" yaml:"initial_uoz_price"` //initial price of uoz
 	TotalUnissuedPrepay sdk.Int       `json:"total_unissued_prepay" yaml:"total_unissued_prepay"`
+	SlashingInfo        []Slashing    `json:"slashing_info" yaml:"slashing_info"`
 }
 
 // NewGenesisState creates a new GenesisState object
 func NewGenesisState(params Params,
 	resourceNodes ResourceNodes,
 	indexingNodes IndexingNodes,
-	initialUOzonePrice sdk.Dec, totalUnissuedPrepay sdk.Int,
+	initialUOzonePrice sdk.Dec,
+	totalUnissuedPrepay sdk.Int,
+	slashingInfo []Slashing,
 ) GenesisState {
 	return GenesisState{
 		Params:              params,
@@ -29,6 +32,7 @@ func NewGenesisState(params Params,
 		IndexingNodes:       indexingNodes,
 		InitialUozPrice:     initialUOzonePrice,
 		TotalUnissuedPrepay: totalUnissuedPrepay,
+		SlashingInfo:        slashingInfo,
 	}
 }
 
@@ -38,6 +42,7 @@ func DefaultGenesisState() GenesisState {
 		Params:              DefaultParams(),
 		InitialUozPrice:     DefaultUozPrice,
 		TotalUnissuedPrepay: DefaultTotalUnissuedPrepay,
+		SlashingInfo:        make([]Slashing, 0),
 	}
 }
 
@@ -113,5 +118,17 @@ func (v GenesisIndexingNode) ToIndexingNode() IndexingNode {
 		Tokens:       tokens,
 		OwnerAddress: ownerAddress,
 		Description:  v.Description,
+	}
+}
+
+type Slashing struct {
+	WalletAddress sdk.AccAddress
+	Value         sdk.Int
+}
+
+func NewSlashing(walletAddress sdk.AccAddress, value sdk.Int) Slashing {
+	return Slashing{
+		WalletAddress: walletAddress,
+		Value:         value,
 	}
 }

--- a/x/register/types/keys.go
+++ b/x/register/types/keys.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	stratos "github.com/stratosnet/stratos-chain/types"
 )
 
@@ -29,6 +30,7 @@ var (
 	IndexingNodeBondedTokenKey    = []byte{0x04}
 	UpperBoundOfTotalOzoneKey     = []byte{0x05}
 	TotalUnissuedPrepayKey        = []byte{0x06}
+	SlashingPrefix                = []byte{0x07}
 
 	InitialGenesisStakeTotalKey = []byte{0x13} // key of initial genesis deposit by all resource nodes and meta nodes at t=0
 	InitialUOzonePriceKey       = []byte{0x14} // key of initial uoz price at t=0
@@ -68,4 +70,9 @@ func GetUBDNodeKey(nodeAddr stratos.SdsAddress) []byte {
 func GetUBDTimeKey(timestamp time.Time) []byte {
 	bz := sdk.FormatTimeBytes(timestamp)
 	return append(UBDNodeQueueKey, bz...)
+}
+
+func GetSlashingKey(walletAddress sdk.AccAddress) []byte {
+	key := append(SlashingPrefix, walletAddress...)
+	return key
 }

--- a/x/sds/app_test.go
+++ b/x/sds/app_test.go
@@ -35,25 +35,30 @@ var (
 	ppNodeOwner4   = sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address())
 	ppNodeOwnerNew = sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address())
 
-	ppNodePubKey1   = ed25519.GenPrivKey().PubKey()
-	ppNodeAddr1     = sdk.AccAddress(ppNodePubKey1.Address())
-	ppInitialStake1 = sdk.NewInt(100000000)
+	ppNodePubKey1    = ed25519.GenPrivKey().PubKey()
+	ppNodeAddr1      = sdk.AccAddress(ppNodePubKey1.Address())
+	ppNodeNetworkId1 = stratos.SdsAddress(ppNodePubKey1.Address())
+	ppInitialStake1  = sdk.NewInt(100000000)
 
-	ppNodePubKey2   = ed25519.GenPrivKey().PubKey()
-	ppNodeAddr2     = sdk.AccAddress(ppNodePubKey2.Address())
-	ppInitialStake2 = sdk.NewInt(100000000)
+	ppNodePubKey2    = ed25519.GenPrivKey().PubKey()
+	ppNodeAddr2      = sdk.AccAddress(ppNodePubKey2.Address())
+	ppNodeNetworkId2 = stratos.SdsAddress(ppNodePubKey2.Address())
+	ppInitialStake2  = sdk.NewInt(100000000)
 
-	ppNodePubKey3   = ed25519.GenPrivKey().PubKey()
-	ppNodeAddr3     = sdk.AccAddress(ppNodePubKey3.Address())
-	ppInitialStake3 = sdk.NewInt(100000000)
+	ppNodePubKey3    = ed25519.GenPrivKey().PubKey()
+	ppNodeAddr3      = sdk.AccAddress(ppNodePubKey3.Address())
+	ppNodeNetworkId3 = stratos.SdsAddress(ppNodePubKey3.Address())
+	ppInitialStake3  = sdk.NewInt(100000000)
 
-	ppNodePubKey4   = ed25519.GenPrivKey().PubKey()
-	ppNodeAddr4     = sdk.AccAddress(ppNodePubKey4.Address())
-	ppInitialStake4 = sdk.NewInt(100000000)
+	ppNodePubKey4    = ed25519.GenPrivKey().PubKey()
+	ppNodeAddr4      = sdk.AccAddress(ppNodePubKey4.Address())
+	ppNodeNetworkId4 = stratos.SdsAddress(ppNodePubKey4.Address())
+	ppInitialStake4  = sdk.NewInt(100000000)
 
-	ppNodePubKeyNew = ed25519.GenPrivKey().PubKey()
-	ppNodeAddrNew   = sdk.AccAddress(ppNodePubKeyNew.Address())
-	ppNodeStakeNew  = sdk.NewInt(100000000)
+	ppNodePubKeyNew    = ed25519.GenPrivKey().PubKey()
+	ppNodeAddrNew      = sdk.AccAddress(ppNodePubKeyNew.Address())
+	ppNodeNetworkIdNew = stratos.SdsAddress(ppNodePubKeyNew.Address())
+	ppNodeStakeNew     = sdk.NewInt(100000000)
 )
 
 func TestMain(m *testing.M) {
@@ -94,7 +99,7 @@ func TestRandomPurchasedUoz(t *testing.T) {
 	registerKeeper.SetRemainingOzoneLimit(ctx, initOzoneLimit)
 	log.Printf("Before: remaining ozone limit is %v \n\n", registerKeeper.GetRemainingOzoneLimit(ctx))
 	for i, val := range resouceNodeTokens {
-		tmpResourceNode := regtypes.NewResourceNode("sds://resourceNode"+strconv.Itoa(i+1), ppNodePubKey1, ppNodeOwner1, regtypes.NewDescription("sds://resourceNode"+strconv.Itoa(i+1), "", "", "", ""), 4, time)
+		tmpResourceNode := regtypes.NewResourceNode(ppNodeNetworkId1, ppNodePubKey1, ppNodeOwner1, regtypes.NewDescription("sds://resourceNode"+strconv.Itoa(i+1), "", "", "", ""), 4, time)
 		tmpResourceNode.Tokens = val
 		tmpResourceNode.Status = sdk.Bonded
 		tmpResourceNode.OwnerAddress = accs[i%5].GetAddress()
@@ -137,7 +142,7 @@ func TestPurchasedUoz(t *testing.T) {
 	registerKeeper.SetRemainingOzoneLimit(ctx, initOzoneLimit)
 	log.Printf("Before: remaining ozone limit is %v \n\n", registerKeeper.GetRemainingOzoneLimit(ctx))
 	for i, val := range resouceNodeTokens {
-		tmpResourceNode := regtypes.NewResourceNode("sds://resourceNode"+strconv.Itoa(i+1), ppNodePubKey1, ppNodeOwner1, regtypes.NewDescription("sds://resourceNode"+strconv.Itoa(i+1), "", "", "", ""), 4, time)
+		tmpResourceNode := regtypes.NewResourceNode(ppNodeNetworkId1, ppNodePubKey1, ppNodeOwner1, regtypes.NewDescription("sds://resourceNode"+strconv.Itoa(i+1), "", "", "", ""), 4, time)
 		tmpResourceNode.Tokens = val
 		tmpResourceNode.Status = sdk.Bonded
 		tmpResourceNode.OwnerAddress = accs[i%5].GetAddress()
@@ -179,7 +184,7 @@ func TestOzoneLimitChange(t *testing.T) {
 	//registerKeeper.SetRemainingOzoneLimit(ctx, initOzoneLimit)
 	log.Printf("Before: remaining ozone limit is %v \n\n", registerKeeper.GetRemainingOzoneLimit(ctx))
 	for i, val := range resouceNodeTokens {
-		tmpResourceNode := regtypes.NewResourceNode("sds://resourceNode"+strconv.Itoa(i+1), ppNodePubKey1, ppNodeOwner1, regtypes.NewDescription("sds://resourceNode"+strconv.Itoa(i+1), "", "", "", ""), 4, time)
+		tmpResourceNode := regtypes.NewResourceNode(ppNodeNetworkId1, ppNodePubKey1, ppNodeOwner1, regtypes.NewDescription("sds://resourceNode"+strconv.Itoa(i+1), "", "", "", ""), 4, time)
 		tmpResourceNode.Tokens = val
 		tmpResourceNode.Status = sdk.Bonded
 		tmpResourceNode.OwnerAddress = accs[i%5].GetAddress()
@@ -411,7 +416,14 @@ func getInitChainer(mapp *mock.App, keeper Keeper, accountKeeper auth.AccountKee
 		resourceNodes := setupAllResourceNodes()
 		indexingNodes := setupAllIndexingNodes()
 
-		registerGenesis := register.NewGenesisState(register.DefaultParams(), resourceNodes, indexingNodes, initialUOzonePrice, sdk.ZeroInt())
+		registerGenesis := register.NewGenesisState(
+			register.DefaultParams(),
+			resourceNodes,
+			indexingNodes,
+			initialUOzonePrice,
+			sdk.ZeroInt(),
+			make([]register.Slashing, 0),
+		)
 
 		register.InitGenesis(ctx, registerKeeper, registerGenesis)
 
@@ -437,7 +449,14 @@ func getInitChainer(mapp *mock.App, keeper Keeper, accountKeeper auth.AccountKee
 		registerKeeper.SetTotalUnissuedPrepay(ctx, totalUnissuedPrepay)
 
 		//pot genesis data load
-		pot.InitGenesis(ctx, potKeeper, pot.NewGenesisState(pottypes.DefaultParams()))
+		pot.InitGenesis(ctx, potKeeper, pot.NewGenesisState(
+			pottypes.DefaultParams(),
+			sdk.NewCoin(pottypes.DefaultRewardDenom, sdk.ZeroInt()),
+			0,
+			make([]pottypes.ImmatureTotal, 0),
+			make([]pottypes.MatureTotal, 0),
+			make([]pottypes.Reward, 0),
+		))
 
 		// init bank genesis
 		keeper.BankKeeper.SetSendEnabled(ctx, true)
@@ -465,7 +484,14 @@ func getInitChainerTestPurchase(mapp *mock.App, keeper Keeper, accountKeeper aut
 		//resourceNodes := setupAllResourceNodes()
 		indexingNodes := setupAllIndexingNodes()
 
-		registerGenesis := register.NewGenesisState(register.DefaultParams(), nil, indexingNodes, initialUOzonePriceTestPurchase, sdk.ZeroInt())
+		registerGenesis := register.NewGenesisState(
+			register.DefaultParams(),
+			nil,
+			indexingNodes,
+			initialUOzonePriceTestPurchase,
+			sdk.ZeroInt(),
+			make([]register.Slashing, 0),
+		)
 
 		register.InitGenesis(ctx, registerKeeper, registerGenesis)
 
@@ -490,7 +516,14 @@ func getInitChainerTestPurchase(mapp *mock.App, keeper Keeper, accountKeeper aut
 		registerKeeper.SetRemainingOzoneLimit(ctx, remainingOzoneLimitTestPurchase)
 
 		//pot genesis data load
-		pot.InitGenesis(ctx, potKeeper, pot.NewGenesisState(pottypes.DefaultParams()))
+		pot.InitGenesis(ctx, potKeeper, pot.NewGenesisState(
+			pottypes.DefaultParams(),
+			sdk.NewCoin(pottypes.DefaultRewardDenom, sdk.ZeroInt()),
+			0,
+			make([]pottypes.ImmatureTotal, 0),
+			make([]pottypes.MatureTotal, 0),
+			make([]pottypes.Reward, 0),
+		))
 
 		registerKeeper.SetTotalUnissuedPrepay(ctx, sdk.NewCoin(potKeeper.BondDenom(ctx), totalUnissuedPrepayTestPurchase))
 		// init bank genesis

--- a/x/sds/app_test.go
+++ b/x/sds/app_test.go
@@ -3,6 +3,7 @@ package sds
 import (
 	"log"
 	"math/rand"
+	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -63,9 +64,9 @@ var (
 
 func TestMain(m *testing.M) {
 	config := stratos.GetConfig()
-
 	config.Seal()
-
+	exitVal := m.Run()
+	os.Exit(exitVal)
 }
 
 func TestRandomPurchasedUoz(t *testing.T) {


### PR DESCRIPTION
1, Move slashing store from pot module to register module.
2, Move slashing genesis info from pot module to register module.
3, Slashing store key is changed from p2p address to wallet address.
4, Deduct slashing amount when:
        a, calculate upcoming mature reward, deduct from mature_total & upcoming mature reward.
        b, unstaking indexing node.
        c, unstaking resource node.
5, Switch reward distribution logic to mainnet.
6, Reward mature issue fixed.
7, Remove reward address pool.
8, Update store keys.
9, Unit test issue fix.

