### PR TITLE
Feat/QB-1241 Make the BaseAcccount compatible with EthAccount 

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -567,7 +567,6 @@ func NewInitApp(
 	// NOTE: this is not required apps that don't use the simulator for fuzz testing
 	// transactions
 	app.sm = module.NewSimulationManager(
-		// Use custom RandomGenesisAccounts so that auth module could create random EthAccounts in genesis state when genesis.json not specified
 		auth.NewAppModule(appCodec, app.accountKeeper, RandomGenesisAccounts),
 		bank.NewAppModule(appCodec, app.bankKeeper, app.accountKeeper),
 		capability.NewAppModule(appCodec, *app.capabilityKeeper),

--- a/app/utils.go
+++ b/app/utils.go
@@ -3,24 +3,15 @@ package app
 import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
-	stratos "github.com/stratosnet/stratos-chain/types"
 )
 
 // RandomGenesisAccounts is used by the auth module to create random genesis accounts in simulation when a genesis.json is not specified.
 // In contrast, the default auth module's RandomGenesisAccounts implementation creates only base accounts and vestings accounts.
 func RandomGenesisAccounts(simState *module.SimulationState) authtypes.GenesisAccounts {
-	emptyCodeHash := crypto.Keccak256(nil)
 	genesisAccs := make(authtypes.GenesisAccounts, len(simState.Accounts))
 	for i, acc := range simState.Accounts {
 		bacc := authtypes.NewBaseAccountWithAddress(acc.Address)
-
-		ethacc := &stratos.EthAccount{
-			BaseAccount: bacc,
-			CodeHash:    common.BytesToHash(emptyCodeHash).String(),
-		}
-		genesisAccs[i] = ethacc
+		genesisAccs[i] = bacc
 	}
 
 	return genesisAccs

--- a/client/keys.go
+++ b/client/keys.go
@@ -14,7 +14,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	clientkeys "github.com/stratosnet/stratos-chain/client/keys"
-	"github.com/stratosnet/stratos-chain/crypto/hd"
+	stratoshd "github.com/stratosnet/stratos-chain/crypto/hd"
 )
 
 // KeyCommands registers a sub-tree of commands to interact with
@@ -50,13 +50,13 @@ The pass backend requires GnuPG: https://gnupg.org/
 	// support adding Ethereum supported keys
 	addCmd := keys.AddKeyCommand()
 
-	// update the default signing algorithm value to "eth_secp256k1"
-	algoFlag := addCmd.Flag("algo")
-	algoFlag.DefValue = string(hd.EthSecp256k1Type)
-	err := algoFlag.Value.Set(string(hd.EthSecp256k1Type))
-	if err != nil {
-		panic(err)
-	}
+	//// update the default signing algorithm value to "eth_secp256k1"
+	//algoFlag := addCmd.Flag("algo")
+	//algoFlag.DefValue = string(hd.EthSecp256k1Type)
+	//err := algoFlag.Value.Set(string(hd.EthSecp256k1Type))
+	//if err != nil {
+	//	panic(err)
+	//}
 
 	addCmd.RunE = runAddCmd
 
@@ -94,7 +94,7 @@ func runAddCmd(cmd *cobra.Command, args []string) error {
 
 	dryRun, _ := cmd.Flags().GetBool(flags.FlagDryRun)
 	if dryRun {
-		kr, err = keyring.New(sdk.KeyringServiceName(), keyring.BackendMemory, clientCtx.KeyringDir, buf, hd.EthSecp256k1Option())
+		kr, err = keyring.New(sdk.KeyringServiceName(), keyring.BackendMemory, clientCtx.KeyringDir, buf, stratoshd.EthSecp256k1Option())
 		clientCtx = clientCtx.WithKeyring(kr)
 	}
 

--- a/client/keys/add.go
+++ b/client/keys/add.go
@@ -80,7 +80,7 @@ Example:
 	f.Uint32(flagCoinType, stratos.GetConfig().GetCoinType(), "coin type number for HD derivation")
 	f.Uint32(flagAccount, 0, "Account number for HD derivation")
 	f.Uint32(flagIndex, 0, "Address index number for HD derivation")
-	f.String(flags.FlagKeyAlgorithm, string(stratoshd.EthSecp256k1Type), "Key signing algorithm to generate keys for")
+	f.String(flags.FlagKeyAlgorithm, string(hd.Secp256k1Type), "Key signing algorithm to generate keys for")
 
 	return cmd
 }

--- a/cmd/stchaind/genaccounts.go
+++ b/cmd/stchaind/genaccounts.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/ethereum/go-ethereum/common"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
@@ -22,8 +20,6 @@ import (
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 
 	"github.com/stratosnet/stratos-chain/crypto/hd"
-	stratos "github.com/stratosnet/stratos-chain/types"
-	evmtypes "github.com/stratosnet/stratos-chain/x/evm/types"
 )
 
 const (
@@ -130,10 +126,7 @@ contain valid denominations. Accounts may optionally be supplied with vesting pa
 					return errors.New("invalid vesting parameters; must supply start and end time or end time")
 				}
 			} else {
-				genAccount = &stratos.EthAccount{
-					BaseAccount: baseAccount,
-					CodeHash:    common.BytesToHash(evmtypes.EmptyCodeHash).Hex(),
-				}
+				genAccount = baseAccount
 			}
 
 			if err := genAccount.Validate(); err != nil {


### PR DESCRIPTION
1, Now is able to use the --algo flag to create accounts for specific key types, the default value is cosmos secp256k1.
2, For normal query with cosmos, returns cosmos base account.
3, Only return eth account for evm related rpc.
4, Use cosmos base account in the genesis file.
5, rename genidxnodes to genmetanodes