### PR TITLE
Feat/QB-1320: Change volume report to be executed at end block

### DIFF
--- a/x/pot/abci.go
+++ b/x/pot/abci.go
@@ -14,6 +14,23 @@ func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k keeper.Keeper) 
 }
 
 // EndBlocker called every block, process inflation, update validator set.
-func EndBlocker(ctx sdk.Context, k keeper.Keeper) {
-	// 	TODO: fill out if your application requires endblock, if not you can delete this function
+func EndBlocker(ctx sdk.Context, req abci.RequestEndBlock, k keeper.Keeper) []abci.ValidatorUpdate {
+
+	walletVolumes, found := k.GetUnhandledReport(ctx)
+	if !found {
+		return []abci.ValidatorUpdate{}
+	}
+	epoch := k.GetUnhandledEpoch(ctx)
+	logger := k.Logger(ctx)
+
+	//distribute POT reward
+	_, err := k.DistributePotReward(ctx, walletVolumes, epoch)
+	if err != nil {
+		logger.Error("An error occurred while distributing the reward. ", err)
+	}
+
+	k.SetUnhandledReport(ctx, nil)
+	k.SetUnhandledEpoch(ctx, sdk.Int{})
+
+	return []abci.ValidatorUpdate{}
 }

--- a/x/pot/keeper/keeper.go
+++ b/x/pot/keeper/keeper.go
@@ -48,14 +48,16 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 }
 
 func (k Keeper) VolumeReport(ctx sdk.Context, walletVolumes []*types.SingleWalletVolume, reporter stratos.SdsAddress,
-	epoch sdk.Int, reportReference string, txHash string) (totalConsumedOzone sdk.Dec, err error) {
+	epoch sdk.Int, reportReference string, txHash string) (err error) {
 	//record volume report
 	reportRecord := types.NewReportRecord(reporter, reportReference, txHash)
 	k.SetVolumeReport(ctx, epoch, reportRecord)
-	//distribute POT reward
-	totalConsumedOzone, err = k.DistributePotReward(ctx, walletVolumes, epoch)
 
-	return totalConsumedOzone, err
+	// save for reward distribution in the EndBlock
+	k.SetUnhandledEpoch(ctx, epoch)
+	k.SetUnhandledReport(ctx, walletVolumes)
+
+	return err
 }
 
 func (k Keeper) IsSPNode(ctx sdk.Context, p2pAddr stratos.SdsAddress) (found bool) {

--- a/x/pot/keeper/msg_server.go
+++ b/x/pot/keeper/msg_server.go
@@ -53,7 +53,7 @@ func (k msgServer) HandleMsgVolumeReport(goCtx context.Context, msg *types.MsgVo
 	txBytes := ctx.TxBytes()
 	txhash := fmt.Sprintf("%X", tmhash.Sum(txBytes))
 
-	totalConsumedOzone, err := k.VolumeReport(ctx, msg.WalletVolumes, reporter, epoch, msg.ReportReference, txhash)
+	err = k.VolumeReport(ctx, msg.WalletVolumes, reporter, epoch, msg.ReportReference, txhash)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +61,6 @@ func (k msgServer) HandleMsgVolumeReport(goCtx context.Context, msg *types.MsgVo
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
 			types.EventTypeVolumeReport,
-			sdk.NewAttribute(types.AttributeKeyTotalConsumedOzone, totalConsumedOzone.String()),
 			sdk.NewAttribute(types.AttributeKeyReportReference, hex.EncodeToString([]byte(msg.ReportReference))),
 			sdk.NewAttribute(types.AttributeKeyEpoch, msg.Epoch.String()),
 		),

--- a/x/pot/keeper/store.go
+++ b/x/pot/keeper/store.go
@@ -117,3 +117,36 @@ func (k Keeper) SetVolumeReport(ctx sdk.Context, epoch sdk.Int, reportRecord typ
 	bz := types.ModuleCdc.MustMarshalLengthPrefixed(reportRecord)
 	store.Set(storeKey, bz)
 }
+
+func (k Keeper) GetUnhandledReport(ctx sdk.Context) (walletVolumes []*types.SingleWalletVolume, found bool) {
+	store := ctx.KVStore(k.storeKey)
+	bz := store.Get(types.UnhandledReportKeyPrefix)
+	if bz == nil {
+		return walletVolumes, false
+	}
+	types.ModuleCdc.MustUnmarshalLengthPrefixed(bz, &walletVolumes)
+	found = true
+	return
+}
+
+func (k Keeper) SetUnhandledReport(ctx sdk.Context, walletVolumes []*types.SingleWalletVolume) {
+	store := ctx.KVStore(k.storeKey)
+	b := types.ModuleCdc.MustMarshalLengthPrefixed(walletVolumes)
+	store.Set(types.UnhandledReportKeyPrefix, b)
+}
+
+func (k Keeper) GetUnhandledEpoch(ctx sdk.Context) (epoch sdk.Int) {
+	store := ctx.KVStore(k.storeKey)
+	b := store.Get(types.UnhandledEpochKey)
+	if b == nil {
+		return sdk.ZeroInt()
+	}
+	types.ModuleCdc.MustUnmarshalLengthPrefixed(b, &epoch)
+	return
+}
+
+func (k Keeper) SetUnhandledEpoch(ctx sdk.Context, epoch sdk.Int) {
+	store := ctx.KVStore(k.storeKey)
+	b := types.ModuleCdc.MustMarshalLengthPrefixed(epoch)
+	store.Set(types.UnhandledEpochKey, b)
+}

--- a/x/pot/module.go
+++ b/x/pot/module.go
@@ -166,8 +166,8 @@ func (am AppModule) BeginBlock(ctx sdk.Context, req abci.RequestBeginBlock) {
 
 // EndBlock returns the end blocker for the pot module. It returns no validator
 // updates.
-func (AppModule) EndBlock(_ sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
-	return []abci.ValidatorUpdate{}
+func (am AppModule) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) []abci.ValidatorUpdate {
+	return EndBlocker(ctx, req, am.keeper)
 }
 
 // RegisterServices registers module services.

--- a/x/pot/types/events.go
+++ b/x/pot/types/events.go
@@ -7,14 +7,14 @@ const (
 	EventTypeFoundationDeposit = "foundation_deposit"
 	EventTypeSlashing          = "slashing"
 
-	AttributeKeyEpoch              = "epoch"
-	AttributeKeyReportReference    = "report_reference"
-	AttributeKeyAmount             = "amount"
-	AttributeKeyWalletAddress      = "wallet_address"
-	AttributeKeyTotalConsumedOzone = "total_consumed_ozone"
-	AttributeKeyNodeP2PAddress     = "p2p_address"
-	AttributeKeySlashingNodeType   = "slashing_type"
-	AttributeKeyNodeSuspended      = "suspend"
+	AttributeKeyEpoch            = "epoch"
+	AttributeKeyReportReference  = "report_reference"
+	AttributeKeyAmount           = "amount"
+	AttributeKeyWalletAddress    = "wallet_address"
+	AttributeKeyNodeP2PAddress   = "p2p_address"
+	AttributeKeySlashingNodeType = "slashing_type"
+	AttributeKeyNodeSuspended    = "suspend"
+	//AttributeKeyTotalConsumedOzone = "total_consumed_ozone"
 
 	AttributeValueCategory = ModuleName
 )

--- a/x/pot/types/key.go
+++ b/x/pot/types/key.go
@@ -28,6 +28,8 @@ var (
 	ImmatureTotalRewardKeyPrefix = []byte{0x15} // key: prefix{address}
 
 	VolumeReportStoreKeyPrefix = []byte{0x41} // VolumeReportStoreKeyPrefix prefix for volumeReport store
+	UnhandledReportKeyPrefix   = []byte{0x42} // prefix for report need to be handled, after reward distribution, clear data
+	UnhandledEpochKey          = []byte{0x43} // prefix for epoch need to be handled, after reward distribution, clear data
 )
 
 func GetMinedTokensKey(epoch sdk.Int) []byte {


### PR DESCRIPTION
1, move reward distribution from VolumeReport tx to endblock
2, remove total_consumed_ozone attribute from volume_report event