### PR TITLE
Feat/QB1494: Add default & minimal value for minimum-gas-prices

### DIFF
--- a/cmd/stchaind/root.go
+++ b/cmd/stchaind/root.go
@@ -255,9 +255,9 @@ func checkMinGasPrices(appOpts servertypes.AppOptions, logger log.Logger) string
 	}
 
 	if minGasPricesInput.IsLT(minimalMinGasPrices) {
-		logger.Info(fmt.Sprintf("min-gas-prices %v is less than minimal value %v, set to default %v",
-			minGasPricesInputStr, minimalMinGasPricesStr, servercfg.GetDefaultMinGasPricesCoinStr()))
-		return servercfg.GetDefaultMinGasPricesCoinStr()
+		logger.Info(fmt.Sprintf("min-gas-prices %v is less than minimal value %v, set to minimal value",
+			minGasPricesInputStr, minimalMinGasPricesStr))
+		return minimalMinGasPricesStr
 	}
 
 	return minGasPricesInput.String()

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -4,9 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"strconv"
 	"time"
 
 	"github.com/spf13/viper"
+	stratos "github.com/stratosnet/stratos-chain/types"
 
 	"github.com/tendermint/tendermint/libs/strings"
 
@@ -46,6 +48,12 @@ const (
 	DefaultHTTPTimeout = 30 * time.Second
 
 	DefaultHTTPIdleTimeout = 120 * time.Second
+
+	// default 1000000000wei = 1gwei
+	DefaultMinGasPrices uint64 = 1e9
+
+	// 1000000wei = 0.01gwei
+	MinimalMinGasPrices uint64 = 1e6
 )
 
 var evmTracers = []string{"json", "markdown", "struct", "access_list"}
@@ -125,9 +133,9 @@ func AppConfig(denom string) (string, interface{}) {
 	// - if you set srvCfg.MinGasPrices non-empty, validators CAN tweak their
 	//   own app.toml to override, or use this default value.
 	//
-	// In stratos, we set the min gas prices to 0.
+	// In stratos, we set the min gas prices to 0.01gwei.
 	if denom != "" {
-		srvCfg.MinGasPrices = "0" + denom
+		srvCfg.MinGasPrices = strconv.FormatUint(DefaultMinGasPrices, 10) + denom
 	}
 
 	customAppConfig := Config{
@@ -330,4 +338,12 @@ func (c Config) ValidateBasic() error {
 	}
 
 	return c.Config.ValidateBasic()
+}
+
+func GetDefaultMinGasPricesCoinStr() string {
+	return strconv.FormatUint(DefaultMinGasPrices, 10) + stratos.Wei
+}
+
+func GetMinimalMinGasPricesCoinStr() string {
+	return strconv.FormatUint(MinimalMinGasPrices, 10) + stratos.Wei
 }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -53,7 +53,7 @@ const (
 	DefaultMinGasPrices uint64 = 1e9
 
 	// 1000000wei = 0.01gwei
-	MinimalMinGasPrices uint64 = 1e6
+	MinimalMinGasPrices uint64 = 1e7
 )
 
 var evmTracers = []string{"json", "markdown", "struct", "access_list"}

--- a/server/start.go
+++ b/server/start.go
@@ -128,7 +128,7 @@ which accepts a path for the resulting pprof file.
 	cmd.Flags().String(srvflags.Address, "tcp://0.0.0.0:26658", "Listen address")
 	cmd.Flags().String(srvflags.Transport, "socket", "Transport protocol: socket, grpc")
 	cmd.Flags().String(srvflags.TraceStore, "", "Enable KVStore tracing to an output file")
-	cmd.Flags().String(server.FlagMinGasPrices, "", "Minimum gas prices to accept for transactions; Any fee in a tx must meet this minimum (e.g. 0.01stos)")
+	cmd.Flags().String(server.FlagMinGasPrices, config.GetDefaultMinGasPricesCoinStr(), "Minimum gas prices to accept for transactions; Any fee in a tx must meet this minimum (e.g. 0.01stos)")
 	cmd.Flags().IntSlice(server.FlagUnsafeSkipUpgrades, []int{}, "Skip a set of upgrade heights to continue the old binary")
 	cmd.Flags().Uint64(server.FlagHaltHeight, 0, "Block height at which to gracefully halt the chain and shutdown the node")
 	cmd.Flags().Uint64(server.FlagHaltTime, 0, "Minimum block time (in Unix seconds) at which to gracefully halt the chain and shutdown the node")


### PR DESCRIPTION
Add default value & minimal value restriction of minimum-gas-prices on app.toml

Default value: 1gwei
Minimal value: 0.01gwei
If value is set less than the minimal value, then use default value instead.