### PR TITLE
fix/QB-1344 Read IAVL cache size from config

### DIFF
--- a/cmd/stchaind/root.go
+++ b/cmd/stchaind/root.go
@@ -238,6 +238,7 @@ func (a appCreator) newApp(logger log.Logger, db dbm.DB, traceStore io.Writer, a
 		baseapp.SetSnapshotStore(snapshotStore),
 		baseapp.SetSnapshotInterval(cast.ToUint64(appOpts.Get(sdkserver.FlagStateSyncSnapshotInterval))),
 		baseapp.SetSnapshotKeepRecent(cast.ToUint32(appOpts.Get(sdkserver.FlagStateSyncSnapshotKeepRecent))),
+		baseapp.SetIAVLCacheSize(cast.ToInt(appOpts.Get("iavl-cache-size"))),
 	)
 }
 


### PR DESCRIPTION
https://qsn.atlassian.net/browse/QB-1344

- Make the BaseApp actually use the IAVL cache size from the config (instead of always using the IAVL default of 500000)
- To reduce memory usage, change the `iavl-cache-size` in `app.toml` to a more reasonable value. The default config value is 781250, which keeps way too many nodes in memory. Maybe 10000 would be more appropriate