### PR TITLE
fix/QB-1344 Read IAVL cache size from config

### DIFF
--- a/cmd/stchaind/root.go
+++ b/cmd/stchaind/root.go
@@ -237,6 +237,7 @@ func (a appCreator) newApp(logger log.Logger, db dbm.DB, traceStore io.Writer, a
 		baseapp.SetSnapshotStore(snapshotStore),
 		baseapp.SetSnapshotInterval(cast.ToUint64(appOpts.Get(sdkserver.FlagStateSyncSnapshotInterval))),
 		baseapp.SetSnapshotKeepRecent(cast.ToUint32(appOpts.Get(sdkserver.FlagStateSyncSnapshotKeepRecent))),
+		baseapp.SetIAVLCacheSize(cast.ToInt(appOpts.Get("iavl-cache-size"))),
 	)
 }
 


### PR DESCRIPTION
Same as https://github.com/stratosnet/stratos-chain/pull/193 but for release branch