### PR TITLE
Fix/Qb-1632: App hash different between build with go1.18 & go1.19

### DIFF
--- a/cmd/stchaind/main.go
+++ b/cmd/stchaind/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"go/doc/comment"
 	"os"
 
 	"github.com/cosmos/cosmos-sdk/server"
@@ -9,6 +10,12 @@ import (
 
 	"github.com/stratosnet/stratos-chain/app"
 	stratos "github.com/stratosnet/stratos-chain/types"
+)
+
+var (
+	// Force to build with go1.19, because sorting algorithm has been rewritten since go1.19
+	// The order of sorted results will be different between go1.18 & go1.19 if the values of the compared elements are equal
+	doc comment.Doc
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stratosnet/stratos-chain
 
-go 1.18
+go 1.19
 
 require (
 	github.com/btcsuite/btcd v0.23.4


### PR DESCRIPTION
Go1.19 rewrite the sort functions.
The order of sorted results will be different between go1.18 & go1.19 if the values of the compared elements are equal.

Import new type introduced by go1.19, forcing to build with go1.19.