### PR TITLE
Fix/Qb-1751: Inconsistent token denoms

### DIFF
--- a/x/sds/keeper/msg_server.go
+++ b/x/sds/keeper/msg_server.go
@@ -67,10 +67,6 @@ func (k msgServer) HandleMsgFileUpload(c context.Context, msg *types.MsgFileUplo
 func (k msgServer) HandleMsgPrepay(c context.Context, msg *types.MsgPrepay) (*types.MsgPrepayResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
 
-	if k.bankKeeper.IsSendEnabledCoin(ctx, sdk.NewCoin(types.DefaultBondDenom, sdk.OneInt())) == false {
-		return &types.MsgPrepayResponse{}, sdkerrors.ErrInvalidCoins
-	}
-
 	sender, err := sdk.AccAddressFromBech32(msg.GetSender())
 	if err != nil {
 		return &types.MsgPrepayResponse{}, sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, err.Error())


### PR DESCRIPTION
Remove unnecessary validation.
Following Prepay() method only accept token with denom defined in the module params.