### PR TITLE
feat/QB-1978: Extend config for web3 rpc

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -81,6 +81,12 @@ type EVMConfig struct {
 type JSONRPCConfig struct {
 	// API defines a list of JSON-RPC namespaces that should be enabled
 	API []string `mapstructure:"api"`
+	// API defines a list of JSON-RPC namespaces that should be enabled
+	CORS []string `mapstructure:"cors"`
+	// API defines a list of JSON-RPC namespaces that should be enabled
+	VHosts []string `mapstructure:"vhosts"`
+	// API defines a list of JSON-RPC namespaces that should be enabled
+	AllowedOrigins []string `mapstructure:"allowed-origins"`
 	// Address defines the HTTP server to listen on
 	Address string `mapstructure:"address"`
 	// WsAddress defines the WebSocket server to listen on
@@ -187,11 +193,29 @@ func GetAPINamespaces() []string {
 	return []string{"web3", "eth", "personal", "net", "txpool", "debug", "miner"}
 }
 
+// GetDefaultAPICors returns the default list of JSON-RPC cors that should be enabled
+func GetDefaultAPICors() []string {
+	return []string{"*"}
+}
+
+// GetDefaultAPIVHosts returns the default list of JSON-RPC vhosts that should be enabled
+func GetDefaultAPIVHosts() []string {
+	return []string{"localhost", "host.docker.internal"}
+}
+
+// GetDefaultAPIAllowedOrigins returns the default list of JSON-RPC allowed origins for WS that should be enabled
+func GetDefaultAPIAllowedOrigins() []string {
+	return []string{}
+}
+
 // DefaultJSONRPCConfig returns an EVM config with the JSON-RPC API enabled by default
 func DefaultJSONRPCConfig() *JSONRPCConfig {
 	return &JSONRPCConfig{
 		Enable:          true,
 		API:             GetDefaultAPINamespaces(),
+		CORS:            GetDefaultAPICors(),
+		VHosts:          GetDefaultAPIVHosts(),
+		AllowedOrigins:  GetDefaultAPIAllowedOrigins(),
 		Address:         DefaultJSONRPCAddress,
 		WsAddress:       DefaultJSONRPCWsAddress,
 		GasCap:          DefaultGasCap,
@@ -298,6 +322,9 @@ func GetConfig(v *viper.Viper) (Config, error) {
 		JSONRPC: JSONRPCConfig{
 			Enable:          v.GetBool("json-rpc.enable"),
 			API:             v.GetStringSlice("json-rpc.api"),
+			CORS:            v.GetStringSlice("json-rpc.cors"),
+			VHosts:          v.GetStringSlice("json-rpc.vhosts"),
+			AllowedOrigins:  v.GetStringSlice("json-rpc.allowed-origins"),
 			Address:         v.GetString("json-rpc.address"),
 			WsAddress:       v.GetString("json-rpc.ws-address"),
 			GasCap:          v.GetUint64("json-rpc.gas-cap"),

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -35,6 +35,18 @@ ws-address = "{{ .JSONRPC.WsAddress }}"
 # Example: "eth,txpool,personal,net,debug,web3"
 api = "{{range $index, $elmt := .JSONRPC.API}}{{if $index}},{{$elmt}}{{else}}{{$elmt}}{{end}}{{end}}"
 
+# API defines a list of JSON-RPC cors that should be enabled
+# Example: "*" to enable for all
+cors = "{{range $index, $elmt := .JSONRPC.CORS}}{{if $index}},{{$elmt}}{{else}}{{$elmt}}{{end}}{{end}}"
+
+# API defines a list of JSON-RPC vhosts that should be enabled
+# Example: "localhost,host.docker.internal"
+vhosts = "{{range $index, $elmt := .JSONRPC.VHosts}}{{if $index}},{{$elmt}}{{else}}{{$elmt}}{{end}}{{end}}"
+
+# API defines a list of JSON-RPC allowed origins for WS that should be enabled
+# Example: "localhost"
+allowed-origins = "{{range $index, $elmt := .JSONRPC.AllowedOrigins}}{{if $index}},{{$elmt}}{{else}}{{$elmt}}{{end}}{{end}}"
+
 # GasCap sets a cap on gas that can be used in eth_call/estimateGas (0=infinite). Default: 25,000,000.
 gas-cap = {{ .JSONRPC.GasCap }}
 

--- a/server/flags/flags.go
+++ b/server/flags/flags.go
@@ -34,6 +34,9 @@ const (
 const (
 	JSONRPCEnable          = "json-rpc.enable"
 	JSONRPCAPI             = "json-rpc.api"
+	JSONRPCCors            = "json-rpc.cors"
+	JSONRPCVHosts          = "json-rpc.vhosts"
+	JSONRPCAllowedOrigins  = "json-rpc.allowed-origins"
 	JSONRPCAddress         = "json-rpc.address"
 	JSONWsAddress          = "json-rpc.ws-address"
 	JSONRPCGasCap          = "json-rpc.gas-cap"

--- a/server/start.go
+++ b/server/start.go
@@ -151,6 +151,9 @@ which accepts a path for the resulting pprof file.
 
 	cmd.Flags().Bool(srvflags.JSONRPCEnable, true, "Define if the gRPC server should be enabled")
 	cmd.Flags().StringSlice(srvflags.JSONRPCAPI, config.GetDefaultAPINamespaces(), "Defines a list of JSON-RPC namespaces that should be enabled")
+	cmd.Flags().StringSlice(srvflags.JSONRPCCors, config.GetDefaultAPICors(), "Defines a list of JSON-RPC cors that should be enabled")
+	cmd.Flags().StringSlice(srvflags.JSONRPCVHosts, config.GetDefaultAPIVHosts(), "Defines a list of JSON-RPC vhosts that should be enabled")
+	cmd.Flags().StringSlice(srvflags.JSONRPCAllowedOrigins, config.GetDefaultAPIAllowedOrigins(), "Defines a list of JSON-RPC allowed origins for WS that should be enabled")
 	cmd.Flags().String(srvflags.JSONRPCAddress, config.DefaultJSONRPCAddress, "the JSON-RPC server address to listen on")
 	cmd.Flags().String(srvflags.JSONWsAddress, config.DefaultJSONRPCWsAddress, "the JSON-RPC WS server address to listen on")
 	cmd.Flags().Uint64(srvflags.JSONRPCGasCap, config.DefaultGasCap, "Sets a cap on gas that can be used in eth_call/estimateGas unit is wei (0=infinite)")


### PR DESCRIPTION
New fields
```
# API defines a list of JSON-RPC cors that should be enabled
# Example: "*" to enable for all
cors = "*"

# API defines a list of JSON-RPC vhosts that should be enabled
# Example: "localhost,host.docker.internal"
vhosts = "localhost,host.docker.internal"

# API defines a list of JSON-RPC allowed origins for WS that should be enabled
# Example: "localhost"
allowed-origins = ""
```

Mostly vhosts required for loadbalancer, but looks like hack with header `Host` on nginx should also work 