### PR TITLE
[Merge step 2] PoC: Any cosmos/stratos msg through MsgEthereumTx

### DIFF
--- a/app/ante/handler_options.go
+++ b/app/ante/handler_options.go
@@ -52,6 +52,7 @@ func newEthAnteHandler(options HandlerOptions) sdk.AnteHandler {
 		NewEthMempoolFeeDecorator(options.EvmKeeper),   // Check eth effective gas price against minimal-gas-prices
 		NewEthValidateBasicDecorator(options.EvmKeeper),
 		NewEthTxPayloadVerificationDecorator(),
+		NewEthTxCosmosMsgVerifierDecorator(options.EvmKeeper), // NEW cosmos msg verifier, loop protector
 		NewEthSigVerificationDecorator(options.EvmKeeper),
 		NewEthAccountVerificationDecorator(options.AccountKeeper, options.EvmKeeper),
 		NewEthGasConsumeDecorator(options.EvmKeeper, options.MaxEthTxGasWanted),

--- a/app/ante/interfaces.go
+++ b/app/ante/interfaces.go
@@ -42,6 +42,7 @@ type EVMKeeper interface {
 	GetBaseFee(ctx sdk.Context, ethCfg *params.ChainConfig) *big.Int
 	GetBalance(ctx sdk.Context, addr common.Address) *big.Int
 	ResetTransientGasUsed(ctx sdk.Context)
+	GetSdkMsg(from sdk.AccAddress, data []byte) (*evmtypes.MsgCosmosData, error)
 }
 
 type protoTxProvider interface {

--- a/app/app.go
+++ b/app/app.go
@@ -238,6 +238,8 @@ func NewStratosApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLates
 	// baseAppOptions = append(baseAppOptions, prepareOpt)
 	app.App = appBuilder.Build(logger, db, traceStore, baseAppOptions...)
 
+	app.evmKeeper.SetMsgServiceRouter(app.App.BaseApp.MsgServiceRouter())
+
 	evmTracer := cast.ToString(appOpts.Get(srvflags.EVMTracer))
 	app.evmKeeper.SetTracer(evmTracer)
 

--- a/rpc/types/utils.go
+++ b/rpc/types/utils.go
@@ -573,7 +573,7 @@ func FindEthereumTxEvent(events []abci.Event, txHash string) (int, *evmtypes.Eve
 		return msgIndex, evtEthTx
 	}
 	// not found
-	return -1, nil
+	return -1, &evmtypes.EventEthereumTx{}
 }
 
 // FindAttribute find event attribute with specified key, if not found returns nil.

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cometbft/cometbft/libs/log"
 
 	"cosmossdk.io/errors"
+	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
@@ -61,6 +62,8 @@ type Keeper struct {
 	// EVM Hooks for tx post-processing
 	hooks types.EvmHooks
 
+	msgServiceRouter *baseapp.MsgServiceRouter
+
 	// the address capable of executing a MsgUpdateParams message. Typically, this
 	// should be the x/gov module account.
 	authority string
@@ -112,6 +115,10 @@ func (k *Keeper) SetParamSpace(paramSpace paramtypes.Subspace) {
 		paramSpace = paramSpace.WithKeyTable(types.ParamKeyTable())
 	}
 	k.paramSpace = paramSpace
+}
+
+func (k *Keeper) SetMsgServiceRouter(msgServiceRouter *baseapp.MsgServiceRouter) {
+	k.msgServiceRouter = msgServiceRouter
 }
 
 func (k *Keeper) SetTracer(tracer string) {

--- a/x/evm/types/msg.go
+++ b/x/evm/types/msg.go
@@ -23,9 +23,9 @@ import (
 
 var (
 	_ sdk.Msg    = &MsgEthereumTx{}
+	_ sdk.Msg    = &MsgUpdateParams{}
 	_ sdk.Tx     = &MsgEthereumTx{}
 	_ ante.GasTx = &MsgEthereumTx{}
-	_ sdk.Msg    = &MsgUpdateParams{}
 
 	_ codectypes.UnpackInterfacesMessage = MsgEthereumTx{}
 )
@@ -149,6 +149,7 @@ func (msg *MsgEthereumTx) FromEthereumTx(tx *ethtypes.Transaction) error {
 	msg.Data = anyTxData
 	msg.Size_ = float64(tx.Size())
 	msg.Hash = tx.Hash().Hex()
+
 	return nil
 }
 
@@ -338,7 +339,9 @@ func (msg *MsgEthereumTx) BuildTx(b client.TxBuilder, evmDenom string) (signing.
 	}
 
 	builder.SetExtensionOptions(option)
-	err = builder.SetMsgs(msg)
+
+	msgs := msg.GetMsgs()
+	err = builder.SetMsgs(msgs...)
 	if err != nil {
 		return nil, err
 	}

--- a/x/evm/types/msg_cosmos.go
+++ b/x/evm/types/msg_cosmos.go
@@ -1,0 +1,167 @@
+package types
+
+import (
+	"bytes"
+
+	"cosmossdk.io/errors"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/gogo/protobuf/proto"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	prototypes "github.com/cosmos/gogoproto/types"
+)
+
+var (
+	_ sdk.Msg                            = &MsgCosmosData{}
+	_ codectypes.UnpackInterfacesMessage = &MsgCosmosData{}
+
+	// Web3CosmosAddress is used as a target for resolve tx data
+	Web3CosmosAddress = common.BytesToAddress([]byte("web3cosmos"))
+)
+
+func IsCosmosHandler(to interface {
+	Bytes() []byte
+}) bool {
+	if to != nil && bytes.Equal(to.Bytes(), Web3CosmosAddress.Bytes()) {
+		return true
+	}
+	return false
+}
+
+// TxDataToMsg convert evm tx data to cosmos any msg
+func TxDataToSdkMsg(cdc codectypes.AnyUnpacker, data []byte) (sdk.Msg, error) {
+	var msgAny prototypes.Any
+	if err := proto.Unmarshal(data, &msgAny); err != nil {
+		return nil, err
+	}
+
+	var pbProto prototypes.DynamicAny
+
+	if err := prototypes.UnmarshalAny(&msgAny, &pbProto); err != nil {
+		return nil, err
+	}
+
+	anyTxData, err := codectypes.NewAnyWithValue(pbProto.Message)
+	if err != nil {
+		return nil, err
+	}
+
+	cMsg, ok := anyTxData.GetCachedValue().(sdk.Msg)
+	if !ok {
+		return nil, err
+	}
+
+	// this should resolved nested anyies in msg
+	if err := codectypes.UnpackInterfaces(cMsg, cdc); err != nil {
+		return nil, err
+	}
+
+	return cMsg, nil
+}
+
+// MsgCosmosData is dynamic data from MsgEthereumTx which will be handled by the router
+type MsgCosmosData struct {
+	cdc  codectypes.AnyUnpacker
+	from sdk.Address
+	msg  sdk.Msg
+}
+
+func NewMsgCosmosData(cdc codectypes.AnyUnpacker, from sdk.Address) *MsgCosmosData {
+	return &MsgCosmosData{cdc: cdc, from: from}
+}
+
+func (mcd *MsgCosmosData) IsNil() bool {
+	return mcd.msg == nil
+}
+
+// SetMsg explisitly (could bypass Parse)
+func (mcd *MsgCosmosData) SetMsg(msg sdk.Msg) {
+	mcd.msg = msg
+}
+
+// Parse tx data to sdk.Msg
+func (mcd *MsgCosmosData) Parse(data []byte) error {
+	cMsg, err := TxDataToSdkMsg(mcd.cdc, data)
+	if err != nil {
+		return err
+	}
+	mcd.SetMsg(cMsg)
+
+	return nil
+}
+
+func (mcd *MsgCosmosData) UnpackInterfaces(unpacker codectypes.AnyUnpacker) error {
+	if mcd.IsNil() {
+		return nil
+	}
+	return codectypes.UnpackInterfaces(mcd.msg, unpacker)
+}
+
+func (mcd *MsgCosmosData) String() string {
+	if mcd.IsNil() {
+		return "No msg"
+	}
+	return mcd.msg.String()
+}
+
+func (mcd *MsgCosmosData) Reset() {}
+
+// ProtoMessage invoke msg ProtoMessage
+func (mcd *MsgCosmosData) ProtoMessage() {
+	if mcd.IsNil() {
+		return
+	}
+	mcd.msg.ProtoMessage()
+}
+
+// GetMsgs returns a single sdk.Msg.
+func (mcd *MsgCosmosData) GetMsgs() []sdk.Msg {
+	if mcd.IsNil() {
+		return []sdk.Msg{}
+	}
+	return []sdk.Msg{mcd.msg}
+}
+
+// GetSigners return signers of sdk.Msg
+func (mcd *MsgCosmosData) GetSigners() []sdk.AccAddress {
+	if mcd.IsNil() {
+		return []sdk.AccAddress{}
+	}
+	return mcd.msg.GetSigners()
+}
+
+// ValidateCosmosMsg validates msg (mostly for ante checks and estimates)
+func (mcd *MsgCosmosData) ValidateBasic() (err error) {
+	// could be occured in nested msg during check if something missed or unparsed (like signers check)
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.Wrapf(sdkerrors.ErrUnknownRequest, "%v", r)
+		}
+	}()
+
+	if mcd.IsNil() {
+		return errors.Wrapf(sdkerrors.ErrUnknownRequest, "msg not found")
+	}
+
+	msg := mcd.GetMsgs()[0]
+
+	// should be first as it is faster to compare and skip tx
+	_, ok := msg.(*MsgEthereumTx)
+	if ok {
+		return errors.Wrapf(sdkerrors.ErrInvalidType, "circular msgs not allowed")
+	}
+
+	cSigners := msg.GetSigners()
+	if len(cSigners) == 0 || mcd.from == nil || !bytes.Equal(cSigners[0], mcd.from.Bytes()) {
+		return errors.Wrapf(sdkerrors.ErrorInvalidSigner, "cosmos signer is not a signer of eth msg")
+	}
+
+	if err := msg.ValidateBasic(); err != nil {
+		return errors.Wrap(err, "tx basic validation failed")
+	}
+
+	return nil
+}

--- a/x/evm/types/utils.go
+++ b/x/evm/types/utils.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 
 	"github.com/gogo/protobuf/proto"
+	"golang.org/x/exp/constraints"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -160,4 +161,11 @@ func BlockMaxGasFromConsensusParams(blockHeight *int64) (int64, error) {
 	}
 
 	return gasLimit, nil
+}
+
+func Max[T constraints.Ordered](a, b T) T {
+	if a < b {
+		return b
+	}
+	return a
 }


### PR DESCRIPTION
Tests (https://github.com/stratosnet/stratos-evm-tests/blob/feat/ST-110/add-ethereum-data-to-cosmos-msg-processing/test/CosmosData.test.js):
[x] Delegate/undelegate
[x] Send/MultiSend
[x] Prepay
[x] Create validator
[x] EVM Mas 

Gas usage delegate: ~72313 Gas (if nobody delegated) ~107871 (if already something delegated)
Gas usage undelegate: ~123335 - 155190 (varies)

(Done) ~~Still not finalized `eth_call` and `eth_estimateGas`. `eth_call` must be implemented in order to check tx before as if tx is failed, it is not marked as failed like normal evm tx.~~