### PR TITLE
Fix/ Set default power reduction on start

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 
+	sdkmath "cosmossdk.io/math"
 	"github.com/spf13/cast"
 
 	dbm "github.com/cometbft/cometbft-db"
@@ -179,6 +180,9 @@ func NewStratosApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLates
 			),
 		)
 	)
+
+	//reset DefaultPowerReduction to prevent voting power overflow.
+	sdk.DefaultPowerReduction = sdkmath.NewInt(1e12)
 
 	if err := depinject.Inject(appConfig,
 		&appBuilder,

--- a/app/app.go
+++ b/app/app.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"os"
 
-	sdkmath "cosmossdk.io/math"
 	"github.com/spf13/cast"
 
 	dbm "github.com/cometbft/cometbft-db"
@@ -180,9 +179,6 @@ func NewStratosApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLates
 			),
 		)
 	)
-
-	//reset DefaultPowerReduction to prevent voting power overflow.
-	sdk.DefaultPowerReduction = sdkmath.NewInt(1e12)
 
 	if err := depinject.Inject(appConfig,
 		&appBuilder,

--- a/app/app_config.go
+++ b/app/app_config.go
@@ -76,7 +76,7 @@ const (
 var (
 	// DefaultNodeHome sets the folder where the application data and configuration will be stored
 	DefaultNodeHome = os.ExpandEnv("$HOME/.stchaind")
-	powerReduction  = sdkmath.NewInt(1e18)
+	powerReduction  = sdkmath.NewInt(1e13)
 
 	// ModuleBasics is in charge of setting up basic module elements
 	ModuleBasics = module.NewBasicManager(

--- a/app/app_config.go
+++ b/app/app_config.go
@@ -76,7 +76,7 @@ const (
 var (
 	// DefaultNodeHome sets the folder where the application data and configuration will be stored
 	DefaultNodeHome = os.ExpandEnv("$HOME/.stchaind")
-	powerReduction  = sdkmath.NewInt(1e13)
+	powerReduction  = sdkmath.NewInt(1e15)
 
 	// ModuleBasics is in charge of setting up basic module elements
 	ModuleBasics = module.NewBasicManager(

--- a/app/app_config.go
+++ b/app/app_config.go
@@ -3,6 +3,8 @@ package app
 import (
 	"os"
 
+	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	ica "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts"
 	icatypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/types"
 	ibcfee "github.com/cosmos/ibc-go/v7/modules/apps/29-fee"
@@ -74,6 +76,7 @@ const (
 var (
 	// DefaultNodeHome sets the folder where the application data and configuration will be stored
 	DefaultNodeHome = os.ExpandEnv("$HOME/.stchaind")
+	powerReduction  = sdkmath.NewInt(1e18)
 
 	// ModuleBasics is in charge of setting up basic module elements
 	ModuleBasics = module.NewBasicManager(
@@ -292,6 +295,9 @@ var (
 
 func init() {
 	version.AppName = appName + "d"
+
+	//reset DefaultPowerReduction to prevent voting power overflow.
+	sdk.DefaultPowerReduction = powerReduction
 }
 
 // GetMaccPerms returns a copy of the module account permissions


### PR DESCRIPTION
Set DefaultPowerReduction to 1e13, which supports 8 digit stos delegation value.
Since total_supply is 100M stos, which is 9 digit integer, this powerReduction is safe enough to prevent overflow.