### PR TITLE
fix/ST-396 prepay rejects 0 amount

### DIFF
--- a/x/sds/types/msg.go
+++ b/x/sds/types/msg.go
@@ -139,7 +139,7 @@ func (msg MsgPrepay) ValidateBasic() error {
 		return ErrInvalidBeneficiaryAddr
 	}
 
-	if msg.Amount.Empty() {
+	if msg.Amount.IsZero() {
 		return errors.Wrap(sdkerrors.ErrInvalidCoins, "missing amount to send")
 	}
 


### PR DESCRIPTION
https://qsn.atlassian.net/browse/ST-396

- reject prepay txs where the amount is 0 (eg: `0stos`)