### PR TITLE
Corrected typos

### DIFF
--- a/api/stratos/evm/v1/proposal.pulsar.go
+++ b/api/stratos/evm/v1/proposal.pulsar.go
@@ -640,7 +640,7 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// UpdateImplmentationProposal used to update implemntation for genesis proxies
+// UpdateImplmentationProposal used to update implementation for genesis proxies
 type UpdateImplmentationProposal struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -648,7 +648,7 @@ type UpdateImplmentationProposal struct {
 
 	// proxy address where data will be executed
 	ProxyAddress string `protobuf:"bytes,1,opt,name=proxy_address,json=proxyAddress,proto3" json:"proxy_address,omitempty"`
-	// implmentation address as API for a storage
+	// implementation address as API for a storage
 	ImplementationAddress string `protobuf:"bytes,2,opt,name=implementation_address,json=implementationAddress,proto3" json:"implementation_address,omitempty"`
 	// data for execution
 	Data []byte `protobuf:"bytes,3,opt,name=data,proto3" json:"data,omitempty"`

--- a/app/ante/eth.go
+++ b/app/ante/eth.go
@@ -55,7 +55,7 @@ func (tpvd EthTxPayloadVerificationDecorator) AnteHandle(ctx sdk.Context, tx sdk
 	return next(ctx, tx, simulate)
 }
 
-// EthTxCosmosMsgVerifierDecorator validates base tx payload if cosmos msg occured and protect from looping
+// EthTxCosmosMsgVerifierDecorator validates base tx payload if cosmos msg occurred and protect from looping
 type EthTxCosmosMsgVerifierDecorator struct {
 	evmKeeper EVMKeeper
 }
@@ -167,7 +167,7 @@ func NewEthAccountVerificationDecorator(ak evmtypes.AccountKeeper, ek EVMKeeper)
 }
 
 // AnteHandle validates checks that the sender balance is greater than the total transaction cost.
-// The account will be set to store if it doesn't exis, i.e cannot be found on store.
+// The account will be set to store if it doesn't exist, exists, exit, exits, axis, lexis, exes, i.e cannot be found on store.
 // This AnteHandler decorator will fail if:
 // - any of the msgs is not a MsgEthereumTx
 // - from address is empty
@@ -308,7 +308,7 @@ func (egcd EthGasConsumeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simula
 	// NOTE: safety check
 	if blockGasLimit > 0 {
 		// generate a copy of the gas pool (i.e block gas meter) to see if we've run out of gas for this block
-		// if current gas consumed is greater than the limit, this funcion panics and the error is recovered on the Baseapp
+		// if current gas consumed is greater than the limit, this function panics and the error is recovered on the Baseapp
 		gasPool := sdk.NewGasMeter(blockGasLimit)
 		gasPool.ConsumeGas(ctx.GasMeter().GasConsumedToLimit(), "gas pool check")
 	}

--- a/crypto/sha3/sha3_test.go
+++ b/crypto/sha3/sha3_test.go
@@ -12,7 +12,7 @@ package sha3
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/flat"
 	"encoding/hex"
 	"encoding/json"
 	"hash"
@@ -23,7 +23,7 @@ import (
 
 const (
 	testString  = "brekeccakkeccak koax koax"
-	katFilename = "testdata/keccakKats.json.deflate"
+	katFilename = "testdata/keccakKats.json.deflat"
 )
 
 // Internal-use instances of SHAKE used to test against KATs.
@@ -75,15 +75,15 @@ func testUnalignedAndGeneric(t *testing.T, testf func(impl string)) {
 
 // TestKeccakKats tests the SHA-3 and Shake implementations against all the
 // ShortMsgKATs from https://github.com/gvanas/KeccakCodePackage
-// (The testvectors are stored in keccakKats.json.deflate due to their length.)
+// (The testvectors are stored in keccakKats.json.deflat due to their length.)
 func TestKeccakKats(t *testing.T) {
 	testUnalignedAndGeneric(t, func(impl string) {
 		// Read the KATs.
-		deflated, err := os.Open(katFilename)
+		deflatd, err := os.Open(katFilename)
 		if err != nil {
 			t.Errorf("error opening %s: %s", katFilename, err)
 		}
-		file := flate.NewReader(deflated)
+		file := flat.NewReader(deflatd)
 		dec := json.NewDecoder(file)
 		var katSet KeccakKats
 		err = dec.Decode(&katSet)

--- a/packages/gov/README.md
+++ b/packages/gov/README.md
@@ -1,6 +1,6 @@
 # Stratos chain gov contracts
 
-This contracts relatd to gov mechanics via proxy calls like:
+This contracts related to gov mechanics via proxy calls like:
  - Prepay
 
 Try running some of the following tasks:

--- a/server/start.go
+++ b/server/start.go
@@ -99,7 +99,7 @@ which accepts a path for the resulting pprof file.
 
 			serverCtx.Logger.Info("Unlocking keyring")
 
-			// fire unlock precess for keyring
+			// fire unlock process for keyring
 			keyringBackend, _ := cmd.Flags().GetString(flags.FlagKeyringBackend)
 			if keyringBackend == keyring.BackendFile {
 				_, err = clientCtx.Keyring.List()

--- a/types/gasmeter.go
+++ b/types/gasmeter.go
@@ -71,7 +71,7 @@ func (g *infiniteGasMeterWithLimit) ConsumeGas(amount sdk.Gas, descriptor string
 // RefundGas will deduct the given amount from the gas consumed. If the amount is greater than the
 // gas consumed, the function will panic.
 //
-// Use case: This functionality enables refunding gas to the trasaction or block gas pools so that
+// Use case: This functionality enables refunding gas to the transaction or block gas pools so that
 // EVM-compatible chains can fully support the go-ethereum StateDb interface.
 // See https://github.com/cosmos/cosmos-sdk/pull/9403 for reference.
 func (g *infiniteGasMeterWithLimit) RefundGas(amount sdk.Gas, descriptor string) {


### PR DESCRIPTION
Changes made in:

- /packages/gov/README.md ("relatd" → "related")

- /crypto/sha3/sha3_test.go ("flate" → "flat")

- /crypto/sha3/sha3_test.go ("flate" → "flat")

- /types/gasmeter.go ("trasaction" → "transaction")

- /app/ante/eth.go ("occured" → "occurred")

- /app/ante/eth.go ("exis" → "exist, exists, exit, exits, axis, lexis, exes")

- /app/ante/eth.go ("funcion" → "function")

- /server/start.go ("precess" → "process")

- /api/stratos/evm/v1/proposal.pulsar.go ("implemntation" → "implementation")

- /api/stratos/evm/v1/proposal.pulsar.go ("implmentation" → "implementation")
